### PR TITLE
#167 Importing countries via admin panel.

### DIFF
--- a/huxley/core/admin.py
+++ b/huxley/core/admin.py
@@ -6,8 +6,8 @@
 import csv
 
 from django.conf.urls import patterns, url
-from django.core.urlresolvers import reverse
 from django.contrib import admin
+from django.core.urlresolvers import reverse
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 
 from huxley.core.models import *
@@ -98,8 +98,32 @@ class CommitteeAdmin(admin.ModelAdmin):
         return urls
 
 
+class CountryAdmin(admin.ModelAdmin):
+    def load(self, request):
+        '''Import a CSV file containing countries.'''
+        countries = request.FILES
+        reader = csv.reader(countries['csv'])
+        for row in reader:
+            c = Country(name=row[0],
+                        special=bool(row[1]))
+            c.save()
+
+        return HttpResponse(reverse('admin:core_country_changelist'))
+
+    def get_urls(self):
+        urls = super(CountryAdmin, self).get_urls()
+        urls += patterns('',
+            url(
+                r'load',
+                self.admin_site.admin_view(self.load),
+                name='core_country_load'
+            ),
+        )
+        return urls
+
+
 admin.site.register(Conference)
-admin.site.register(Country)
+admin.site.register(Country, CountryAdmin)
 admin.site.register(School)
 admin.site.register(Committee, CommitteeAdmin)
 admin.site.register(Assignment, AssignmentAdmin)

--- a/huxley/core/tests.py
+++ b/huxley/core/tests.py
@@ -170,3 +170,33 @@ class CommitteeAdminTest(TestCase):
             delegation_size=2,
             special=True
         ).exists())
+
+
+class CountryAdminTest(TestCase):
+
+    def test_import(self):
+        ''' Test that the admin panel can import countries. '''
+        TestUsers.new_superuser(username='testuser', password='test')
+        self.client.login(username='testuser', password='test')
+
+        f = TestFiles.new_csv([
+            ['United States of America', ''],
+            ['Barbara Boxer', True],
+            ["Côte d'Ivoire", '']
+        ])
+
+        with closing(f) as f:
+            self.client.post(reverse('admin:core_country_load'), {'csv': f})
+
+        self.assertTrue(Country.objects.filter(
+            name='United States of America',
+            special=False
+        ).exists())
+        self.assertTrue(Country.objects.filter(
+            name='Barbara Boxer',
+            special=True
+        ).exists())
+        self.assertTrue(Country.objects.filter(
+            name="Côte d'Ivoire",
+            special=False
+        ).exists())

--- a/huxley/templates/admin/core/country/change_list.html
+++ b/huxley/templates/admin/core/country/change_list.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_list.html" %}
+
+{% load i18n admin_static admin_list %}
+{% load url from future %}
+{% load admin_urls %}
+
+{% block object-tools %}
+  {{ block.super }}
+  <form action="{% url cl.opts|admin_urlname:'load' %}" enctype="multipart/form-data" method="post">
+    {% csrf_token %}
+    Import Countries
+    <input type="file" name="csv" />
+    <input type="submit" />
+  </form>
+{% endblock %}


### PR DESCRIPTION
Includes the functionality to import countries via the admin panel, along with an appropriate appearance on the browser and a unit test to ensure that a country, a special country, and a country with non-ASCII characters can be imported on a CSV file.
