### PR TITLE
Remove 'www' prefix from the new URLs.

### DIFF
--- a/huxley/core/context_processors.py
+++ b/huxley/core/context_processors.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
-from django.core.urlresolvers import reverse
 
 def conference(request):
     return {'conference' : request.conference}
@@ -13,8 +12,3 @@ def user_type(request):
         return {'user_type': 'advisor'}
     elif request.user.is_chair():
         return {'user_type': 'chair'}
-
-def default_path(request):
-    if not request.user.is_authenticated():
-        return {'default_path': reverse('accounts:login')}
-    return {}

--- a/huxley/settings/main.py
+++ b/huxley/settings/main.py
@@ -57,7 +57,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.messages.context_processors.messages',
     'huxley.core.context_processors.conference',
     'huxley.core.context_processors.user_type',
-    'huxley.core.context_processors.default_path',
 )
 
 TEMPLATE_LOADERS = (

--- a/huxley/urls.py
+++ b/huxley/urls.py
@@ -9,11 +9,9 @@ from django.views.generic import RedirectView
 admin.autodiscover()
 
 urlpatterns = patterns('',
-    url(r'^$', 'huxley.core.views.index', name='index'),
-    url(r'^', include('huxley.accounts.urls', app_name='accounts', namespace='accounts')),
-    url(r'^www/', include('huxley.www.urls', app_name='www', namespace='www')),
-    url(r'^api/', include('huxley.api.urls', app_name='api', namespace='api')),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^api/', include('huxley.api.urls', app_name='api', namespace='api')),
+    url(r'^', include('huxley.www.urls', app_name='www', namespace='www')),
 )
 
 urlpatterns += patterns('',

--- a/huxley/www/static/js/huxley.browserify.js
+++ b/huxley/www/static/js/huxley.browserify.js
@@ -29,14 +29,13 @@ var Route = RRouter.Route;
 
 var routes = (
   <Routes>
-    <Route name="www" path="/www" view={RedirectView}>
-      <Route path="/login" view={LoginView} />
-      <Route path="/password" view={ForgotPasswordView} />
-      <Route path="/password/reset" view={PasswordResetSuccessView} />
-      <Route path="/register" view={RegistrationView} />
-      <Route path="/register/success" view={RegistrationSuccessView} />
-      <Route path="/advisor/profile" view={AdvisorProfileView} />
-    </Route>
+    <Route path="/" view={RedirectView} />
+    <Route path="/login" view={LoginView} />
+    <Route path="/password" view={ForgotPasswordView} />
+    <Route path="/password/reset" view={PasswordResetSuccessView} />
+    <Route path="/register" view={RegistrationView} />
+    <Route path="/register/success" view={RegistrationSuccessView} />
+    <Route path="/advisor/profile" view={AdvisorProfileView} />
   </Routes>
 );
 

--- a/huxley/www/static/js/huxley/Huxley.js
+++ b/huxley/www/static/js/huxley/Huxley.js
@@ -20,9 +20,9 @@ var Huxley = React.createClass({
     CurrentUserStore.addChangeListener(function() {
       var user = CurrentUserStore.getCurrentUser();
       if (user.isAnonymous()) {
-        this.navigate('/www/login');
+        this.navigate('/login');
       } else if (user.isAdvisor()) {
-        this.navigate('/www/advisor/profile');
+        this.navigate('/advisor/profile');
       }
     }.bind(this));
   },

--- a/huxley/www/static/js/huxley/components/ForgotPasswordView.js
+++ b/huxley/www/static/js/huxley/components/ForgotPasswordView.js
@@ -37,7 +37,7 @@ var ForgotPasswordView = React.createClass({
         <h1>Forgot your Password?</h1>
         <p>No problem. Just enter your username below, and we'll send a
         temporary password to your email address.</p>
-        <NavLink direction="left" href="/www/login">
+        <NavLink direction="left" href="/login">
           Back to Login
         </NavLink>
         <hr />
@@ -93,7 +93,7 @@ var ForgotPasswordView = React.createClass({
   },
 
   _handleSuccess: function(data, status, jqXHR) {
-    this.navigate('/www/password/reset');
+    this.navigate('/password/reset');
   },
 
   _handleError: function(jqXHR, status, error) {

--- a/huxley/www/static/js/huxley/components/LoginView.js
+++ b/huxley/www/static/js/huxley/components/LoginView.js
@@ -40,7 +40,7 @@ var LoginView = React.createClass({
       return;
     }
     if (this.props.user.isAdvisor()) {
-      this.navigate('/www/advisor/profile');
+      this.navigate('/advisor/profile');
     }
   },
 
@@ -75,11 +75,11 @@ var LoginView = React.createClass({
               type="submit">
               Log In
             </Button>
-            <Button color="green" href="/www/register">
+            <Button color="green" href="/register">
               Register for BMUN
             </Button>
           </div>
-          <NavLink direction="left" href="/www/password">
+          <NavLink direction="left" href="/password">
             Forgot your password?
           </NavLink>
           {this.renderError()}

--- a/huxley/www/static/js/huxley/components/PasswordResetSuccessView.js
+++ b/huxley/www/static/js/huxley/components/PasswordResetSuccessView.js
@@ -21,7 +21,7 @@ var PasswordResetSuccessView = React.createClass({
           We've sent a temporary password to the email address in your account.
           Please use it to log in and change your password.
         </p>
-        <NavLink direction="left" href="/www/login">
+        <NavLink direction="left" href="/login">
           Back to Login
         </NavLink>
       </OuterView>

--- a/huxley/www/static/js/huxley/components/RedirectView.js
+++ b/huxley/www/static/js/huxley/components/RedirectView.js
@@ -17,9 +17,9 @@ var RedirectView = React.createClass({
 
   componentDidMount: function() {
     if (this.props.user.isAnonymous()) {
-      this.navigate('/www/login');
+      this.navigate('/login');
     } else if (this.props.user.isAdvisor()) {
-      this.navigate('/www/advisor/profile');
+      this.navigate('/advisor/profile');
     }
   },
 

--- a/huxley/www/static/js/huxley/components/RegistrationSuccessView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationSuccessView.js
@@ -70,7 +70,7 @@ var RegistrationSuccessView = React.createClass({
           </p>
         </div>
         <hr />
-        <NavLink direction="right" href="/www/login">
+        <NavLink direction="right" href="/login">
           Proceed to Login
         </NavLink>
       </OuterView>

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -100,7 +100,7 @@ var RegistrationView = React.createClass({
             <p>Please fill out the following information to register your school
             for BMUN 63. All fields are required except for Secondary Contact
             information.</p>
-            <NavLink direction="left" href="/www/login">
+            <NavLink direction="left" href="/login">
               Back to Login
             </NavLink>
           </div>
@@ -382,7 +382,7 @@ var RegistrationView = React.createClass({
               valueLink={this.linkState('registration_comments')}
             />
             <hr />
-              <NavLink direction="left" href="/www/login">
+              <NavLink direction="left" href="/login">
                 Back to Login
               </NavLink>
               <div className="right">
@@ -612,7 +612,7 @@ var RegistrationView = React.createClass({
   },
 
   _handleSuccess: function(data, status, jqXHR) {
-    this.navigate('/www/register/success');
+    this.navigate('/register/success');
   },
 
   _handleError: function(jqXHR, status, error) {


### PR DESCRIPTION
This removes the 'www' namespace from the React app, making it the
default. The app is close to readiness, and all that's required is
polish.

Test Plan: Load `/`, verify it redirects to `/login`. Ensure that
`/login`, `/register`, `/password`, and `/advisor/profile` work as expected.
