### PR TITLE
Support saving country preferences during registration.

### DIFF
--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -6,8 +6,9 @@ from datetime import date
 
 from django.test import TestCase
 
-from huxley.core.models import Committee, Conference, Country, CountryPreference
-
+from huxley.core.models import (Committee, Conference, Country,
+                                CountryPreference, School)
+from huxley.utils.test import TestSchools
 
 class ConferenceTest(TestCase):
 
@@ -81,3 +82,19 @@ class CountryPreferenceTest(TestCase):
     def test_unicode(self):
         """ Tests that the object's __unicode__ outputs correctly. """
         pass
+
+
+class SchoolTest(TestCase):
+
+    def test_update_country_preferences(self):
+        school = TestSchools.new_school()
+        country_ids = [0, 1, 2, 2, 0, 3]
+        self.assertEquals(0, CountryPreference.objects.all().count())
+
+        prefs = School.update_country_preferences(school.id, country_ids)
+        self.assertEquals([1, 2, 3], prefs)
+
+        self.assertEquals(3, CountryPreference.objects.all().count())
+        for i, country_preference in enumerate(CountryPreference.objects.all()):
+            self.assertEquals(prefs[i], country_preference.country_id)
+            self.assertEquals(school.id, country_preference.school_id)

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -624,7 +624,7 @@ var RegistrationView = React.createClass({
           secondary_email: this.state.secondary_email,
           secondary_phone: this.state.secondary_phone,
           secondary_type: this.state.secondary_type,
-          countrypreferences: [
+          country_preferences: [
             this.state.country_pref1,
             this.state.country_pref2,
             this.state.country_pref3,


### PR DESCRIPTION
Since Django Rest Framework doesn't support writing Many-to-Many
fields that have a "through" model, this hacks it together by
intercepting the create request, and manually creating the
country preferences.

This means that we don't have serializer support for it yet, so
we're going to have to do more work if we want to display the
advisor's preferences in the UI.

**Test Plan**: Added unit tests. Registered manually, went into the admin panel and verified my country preferences were there with the correct ranks.
