### PR TITLE
Calculate fees based on School's pre_save signal.

### DIFF
--- a/huxley/core/fixtures/advisor.json
+++ b/huxley/core/fixtures/advisor.json
@@ -24,30 +24,25 @@
     "model": "core.school",
     "fields": {
       "city": "Houston",
-      "delegation_fee": "0",
       "primary_phone": "(281) 330-8004",
       "program_type": 1,
-      "delegation_fee_paid": "0",
       "state": "Texas",
       "primary_name": "Mike Jones",
       "primary_email": "mikejones69@bmun.org",
       "secondary_phone": "",
       "international": false,
-      "delegation_fee_balance": "0",
       "zip_code": "77002",
       "registered": "2013-06-09T16:24:11.302",
       "address": "100 Still Tippin Blvd.",
-      "registration_fee_paid": "0",
       "name": "Who Is Mike Jones?",
       "secondary_email": "",
-      "registration_fee_balance": "0",
       "times_attended": 0,
       "secondary_name": "",
-      "registration_fee": "50",
       "beginner_delegates": 5,
       "intermediate_delegates": 5,
       "advanced_delegates": 5,
-      "spanish_speaking_delegates": 5
+      "spanish_speaking_delegates": 5,
+      "fees_paid": 0.0
     }
   }
 ]

--- a/huxley/core/tests/admin/test_school.py
+++ b/huxley/core/tests/admin/test_school.py
@@ -54,7 +54,7 @@ class SchoolAdminTest(TestCase):
             "Registration Comments",
             "Fees Owed",
             "Fees Paid",
-            ]
+        ]
 
         fields_csv = ",".join(map(str, header)) + "\r\n"
 
@@ -88,8 +88,8 @@ class SchoolAdminTest(TestCase):
             school.prefers_small_specialized,
             school.prefers_mid_large_specialized,
             school.registration_comments,
-            school.fees_owed,
-            school.fees_paid,
+            int(school.fees_owed),
+            int(school.fees_paid),
         ]
 
         fields_csv += ",".join(map(str, fields))

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -98,3 +98,28 @@ class SchoolTest(TestCase):
         for i, country_preference in enumerate(CountryPreference.objects.all()):
             self.assertEquals(prefs[i], country_preference.country_id)
             self.assertEquals(school.id, country_preference.school_id)
+
+    def test_update_fees(self):
+        '''Fees should be calculated when a School is created/updated.'''
+        b, i, a = 3, 5, 7
+        school = TestSchools.new_school(
+            beginner_delegates=b,
+            intermediate_delegates=i,
+            advanced_delegates=a,
+        )
+
+        self.assertEquals(
+            school.fees_owed,
+            school.REGISTRATION_FEE + school.DELEGATE_FEE * (b + i + a),
+        )
+
+        b2, i2, a2 = 5, 10, 15
+        school.beginner_delegates = b2
+        school.intermediate_delegates = i2
+        school.advanced_delegates = a2
+        school.save()
+
+        self.assertEquals(
+            school.fees_owed,
+            school.REGISTRATION_FEE + school.DELEGATE_FEE * (b2 + i2 + a2),
+        )


### PR DESCRIPTION
This recalculates a school's fees every time it's saved, with the formulate `registration_fee + delegation_fee * total_delegates`.

Question for @sdot5: do we want to use the estimated delegate numbers given by the advisors to calculate the delegate fees? I can imagine some advisors being upset about that. We could tell them that this is just based on the estimate, and will change. Or, we could only do registration fee for now.

**Test Plan**: Added a test case, verified the updating behavior in the admin panel.
