### PR TITLE
#303 Removed icon in error label of RegistrationView.

### DIFF
--- a/huxley/www/static/scss/accounts/registration.scss
+++ b/huxley/www/static/scss/accounts/registration.scss
@@ -39,11 +39,11 @@
 
     label.hint
     {
+        background: none;
         display: block;
         font-size: 11px;
         line-height: 1.4;
         padding: 3px 5px 0;
-        background: None
 
         & + input[type=text], & + input[type=password]
         {


### PR DESCRIPTION
Adjusted scss in the RegistrationView so that the error label didn't have the exclamation mark icon.
![screen shot 2014-09-14 at 11 21 52 pm](https://cloud.githubusercontent.com/assets/5726560/4267681/cd85c4e8-3ca0-11e4-8b45-74ff61812c7a.png)
