### PR TITLE
Use console email backend in development.

### DIFF
--- a/huxley/accounts/models.py
+++ b/huxley/accounts/models.py
@@ -65,11 +65,10 @@ class User(AbstractUser):
         user.set_password(new_password)
         user.save()
 
-        if not settings.DEBUG:
-            user.email_user('Huxley Password Reset',
-                            'Your password has been reset to %s.\n'
-                            'Thank you for using Huxley!' % (new_password),
-                            from_email="no-reply@bmun.org")
+        user.email_user('Huxley Password Reset',
+                        'Your password has been reset to %s.\n'
+                        'Thank you for using Huxley!' % (new_password),
+                        from_email='no-reply@bmun.org')
 
     def change_password(self, old_password, new_password):
         '''Change the user's password, or raise PasswordChangeFailed.'''

--- a/huxley/settings/local.py.default
+++ b/huxley/settings/local.py.default
@@ -27,6 +27,7 @@ DATABASES = {
 
 STATIC_ROOT = 'static_root' # Where your static files will be collected.
 
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'email_host'                   # Mail server hostname.
 EMAIL_HOST_USER = 'email_host_user'         # Username for the mail server.
 EMAIL_HOST_PASSWORD = 'email_host_password' # Password

--- a/huxley/settings/main.py
+++ b/huxley/settings/main.py
@@ -34,6 +34,8 @@ LANGUAGE_CODE = 'en-us'
 USE_I18N = False
 USE_L10N = False
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 MEDIA_ROOT = ''
 MEDIA_URL = ''
 ADMIN_MEDIA_PREFIX = '/static/admin/'


### PR DESCRIPTION
This uses the console backend in development, and adds the SMTP backend
to the default deployment settings.

**Test Plan:** Reset a test user's password; verify it shows up in the console.
