### PR TITLE
Add a List API for Assignments.

### DIFF
--- a/huxley/api/permissions.py
+++ b/huxley/api/permissions.py
@@ -26,6 +26,20 @@ class IsAdvisorOrSuperuser(permissions.BasePermission):
         return request.user.is_superuser or request.user == obj.advisor
 
 
+class IsSchoolAdvisorOrSuperuser(permissions.BasePermission):
+    '''Accept only the advisor of the given school_id query param.'''
+
+    def has_permission(self, request, view):
+        if request.user.is_superuser:
+            return True
+
+        school_id = view.kwargs.get('pk', None)
+        user = request.user
+
+        return (user.is_authenticated() and user.is_advisor() and
+                user.school_id == int(school_id))
+
+
 class IsPostOrSuperuserOnly(permissions.BasePermission):
     '''Accept POST (create) requests, superusers-only otherwise.'''
 

--- a/huxley/api/serializers/__init__.py
+++ b/huxley/api/serializers/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
+from .assignment import AssignmentSerializer
 from .committee import CommitteeSerializer
 from .country import CountrySerializer
 from .school import SchoolSerializer

--- a/huxley/api/serializers/assignment.py
+++ b/huxley/api/serializers/assignment.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
+# Use of this source code is governed by a BSD License (see LICENSE).
+
+from rest_framework import serializers
+
+from huxley.core.models import Assignment
+
+
+class AssignmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Assignment
+        fields = ('id', 'committee', 'country', 'school')

--- a/huxley/api/tests/school/test_school_assignments.py
+++ b/huxley/api/tests/school/test_school_assignments.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
+# Use of this source code is governed by a BSD License (see LICENSE).
+
+from huxley.api.tests import ListAPITestCase
+from huxley.core.models import Assignment
+from huxley.utils.test import (TestCommittees, TestCountries, TestSchools,
+                               TestUsers)
+
+
+class SchoolAssignmentsGetTestCase(ListAPITestCase):
+    url_name = 'api:school_assignments'
+    is_resource = True
+
+    def setUp(self):
+        self.user = TestUsers.new_user(username='regular', password='user')
+        self.school = TestSchools.new_school(user=self.user)
+        self.country = TestCountries.new_country()
+        self.committee1 = TestCommittees.new_committee()
+        self.committee2 = TestCommittees.new_committee()
+        self.assignment1 = Assignment.objects.create(
+            committee=self.committee1,
+            country=self.country,
+            school=self.school,
+        )
+        self.assignment2 = Assignment.objects.create(
+            committee=self.committee2,
+            country=self.country,
+            school=self.school,
+        )
+
+    def test_anonymous_user(self):
+        '''It rejects a request from an anonymous user.'''
+        response = self.get_response(self.school.id)
+        self.assertNotAuthenticated(response)
+
+    def test_advisor(self):
+        '''It returns the assignments for the school's advisor.'''
+        self.client.login(username='regular', password='user')
+
+        response = self.get_response(self.school.id)
+        self.assert_assignments_equal(response)
+
+    def test_other_user(self):
+        '''It rejects a request from another user.'''
+        user2 = TestUsers.new_user(username='another', password='user')
+        TestSchools.new_school(user=user2)
+        self.client.login(username='another', password='user')
+
+        response = self.get_response(self.school.id)
+        self.assertPermissionDenied(response)
+
+    def test_superuser(self):
+        '''It returns the assignments for a superuser.'''
+        TestUsers.new_superuser(username='test', password='user')
+        self.client.login(username='test', password='user')
+
+        response = self.get_response(self.school.id)
+        self.assert_assignments_equal(response)
+
+    def assert_assignments_equal(self, response):
+        '''Assert that the response contains the assignments in order.'''
+        self.assertEqual(response.data, [
+            {
+                'id': self.assignment1.id,
+                'country': self.country.id,
+                'committee': self.committee1.id,
+                'school': self.school.id,
+            },
+            {
+                'id': self.assignment2.id,
+                'country': self.country.id,
+                'committee': self.committee2.id,
+                'school': self.school.id,
+            },
+        ])

--- a/huxley/api/urls.py
+++ b/huxley/api/urls.py
@@ -26,6 +26,7 @@ urlpatterns += patterns('',
 urlpatterns += patterns('',
     url(r'^schools/?$', views.school.SchoolList.as_view(), name='school_list'),
     url(r'^schools/(?P<pk>[0-9]+)/?$', views.school.SchoolDetail.as_view(), name='school_detail'),
+    url(r'^schools/(?P<pk>[0-9]+)/assignments/?$', views.school.SchoolAssignments.as_view(), name='school_assignments'),
 )
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/huxley/api/views/school.py
+++ b/huxley/api/views/school.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
+from django.http import Http404
 from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
 
-from huxley.api.permissions import IsAdvisorOrSuperuser
-from huxley.api.serializers import SchoolSerializer
-from huxley.core.models import School
+from huxley.api.permissions import IsAdvisorOrSuperuser, IsSchoolAdvisorOrSuperuser
+from huxley.api.serializers import AssignmentSerializer, SchoolSerializer
+from huxley.core.models import Assignment, School
 
 
 class SchoolList(generics.CreateAPIView):
@@ -36,3 +37,17 @@ class SchoolDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = School.objects.all()
     serializer_class = SchoolSerializer
     permission_classes = (IsAdvisorOrSuperuser,)
+
+
+class SchoolAssignments(generics.ListAPIView):
+    authentication_classes = (SessionAuthentication,)
+    serializer_class = AssignmentSerializer
+    permission_classes = (IsSchoolAdvisorOrSuperuser,)
+
+    def get_queryset(self):
+        '''Filter schools by the given pk param.'''
+        school_id = self.kwargs.get('pk', None)
+        if not school_id:
+            raise Http404
+
+        return Assignment.objects.filter(school_id=school_id)

--- a/huxley/utils/test.py
+++ b/huxley/utils/test.py
@@ -59,11 +59,19 @@ class TestSchools():
                    spanish_speaking_delegates=kwargs.pop('spanish_speaking_delegates', 0),
                    registration_comments=kwargs.pop('registration_comments', ''))
 
+        user = kwargs.pop('user', None)
         for attr, value in kwargs.items():
             setattr(s, attr, value)
 
         s.save()
-        TestUsers.new_user(school=s, committee=TestCommittees.new_committee())
+
+        if user is None:
+          committee = TestCommittees.new_committee()
+          TestUsers.new_user(school=s, committee=committee)
+        else:
+          user.school = s;
+          user.save()
+
         return s
 
 


### PR DESCRIPTION
This adds an API that lists a school's assignments at the URL
`/school/:id/assignments`. It's accessible only by the school's
advisor, and superusers.

Resolves #316.

**Test Plan:** Added test cases.
