### PR TITLE
Use react-router instead of rrouter and update JS dependencies.

### DIFF
--- a/huxley/www/static/js/huxley.browserify.js
+++ b/huxley/www/static/js/huxley.browserify.js
@@ -11,7 +11,7 @@ require('jquery.cookie');
 
 var $ = require('jquery');
 var React = require('react');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var CurrentUserStore = require('./huxley/stores/CurrentUserStore');
 var Huxley = require('./huxley/Huxley');
@@ -27,27 +27,28 @@ var RegistrationClosedView = require('./huxley/components/RegistrationClosedView
 var RegistrationSuccessView = require('./huxley/components/RegistrationSuccessView');
 var RegistrationWaitlistView = require('./huxley/components/RegistrationWaitlistView');
 
-var Routes = RRouter.Routes;
-var Route = RRouter.Route;
+var DefaultRoute = Router.DefaultRoute;
+var Routes = Router.Routes;
+var Route = Router.Route;
 
 var routes = (
-  <Routes>
-    <Route path="/" view={RedirectView} />
-    <Route path="/login" view={LoginView} />
-    <Route path="/password" view={ForgotPasswordView} />
-    <Route path="/password/reset" view={PasswordResetSuccessView} />
-    <Route path="/register" view={RegistrationClosedView} />
-    <Route path="/register/success" view={RegistrationSuccessView} />
-    <Route path="/register/waitlist" view={RegistrationWaitlistView} />
-    <Route path="/advisor/profile" view={AdvisorProfileView} />
-    <Route path="/advisor/assignments" view={AdvisorAssignmentsView} />
-  </Routes>
+  <Route path="/" handler={Huxley}>
+    <Route path="/login" handler={LoginView} />
+    <Route path="/password" handler={ForgotPasswordView} />
+    <Route path="/password/reset" handler={PasswordResetSuccessView} />
+    <Route path="/register" handler={RegistrationClosedView} />
+    <Route path="/register/success" handler={RegistrationSuccessView} />
+    <Route path="/register/waitlist" handler={RegistrationWaitlistView} />
+    <Route path="/advisor/profile" handler={AdvisorProfileView} />
+    <Route path="/advisor/assignments" handler={AdvisorAssignmentsView} />
+    <DefaultRoute handler={RedirectView} />
+  </Route>
 );
 
 $(function() {
-  RRouter.start(routes, function(view) {
-    React.renderComponent(
-      <Huxley view={view} />,
+  Router.run(routes, function(Handler) {
+    React.render(
+      <Handler />,
       document.getElementById('huxley-app')
     );
   });

--- a/huxley/www/static/js/huxley/Huxley.js
+++ b/huxley/www/static/js/huxley/Huxley.js
@@ -8,30 +8,28 @@
 'use strict';
 
 var React = require('react/addons');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 var CurrentUserStore = require('./stores/CurrentUserStore');
 
-var cloneWithProps = React.addons.cloneWithProps;
+var RouteHandler = Router.RouteHandler;
 
 var Huxley = React.createClass({
-  mixins: [RRouter.RoutingContextMixin],
+  mixins: [Router.Navigation],
 
   componentWillMount: function() {
     CurrentUserStore.addChangeListener(function() {
       var user = CurrentUserStore.getCurrentUser();
       if (user.isAnonymous()) {
-        this.navigate('/login');
+        this.transitionTo('/login');
       } else if (user.isAdvisor()) {
-        this.navigate('/advisor/profile');
+        this.transitionTo('/advisor/profile');
       }
     }.bind(this));
   },
 
   render: function() {
-    return cloneWithProps(this.props.view, {
-      user: CurrentUserStore.getCurrentUser()
-    });
-  }
+    return <RouteHandler user={CurrentUserStore.getCurrentUser()} />;
+  },
 });
 
 module.exports = Huxley;

--- a/huxley/www/static/js/huxley/components/AdvisorView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorView.js
@@ -8,17 +8,17 @@
 'use strict';
 
 var React = require('react');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var InnerView = require('./InnerView');
 var PermissionDeniedView = require('./PermissionDeniedView');
 
 var AdvisorView = React.createClass ({
-  mixins: [RRouter.RoutingContextMixin],
+  mixins: [Router.Navigation],
 
   componentDidMount: function() {
     if (this.props.user.isAnonymous()) {
-      this.navigate('/login');
+      this.transitionTo('/login');
     }
   },
 

--- a/huxley/www/static/js/huxley/components/Button.js
+++ b/huxley/www/static/js/huxley/components/Button.js
@@ -8,7 +8,7 @@
 'use strict';
 
 var React = require('react/addons');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var Button = React.createClass({
   propTypes: {
@@ -28,7 +28,7 @@ var Button = React.createClass({
 
   render: function() {
     var cx = React.addons.classSet;
-    var ButtonComponent = this.props.href ? RRouter.Link : React.DOM.button;
+    var ButtonComponent = this.props.href ? Router.Link : React.DOM.button;
 
     return this.transferPropsTo(
       <ButtonComponent
@@ -41,7 +41,8 @@ var Button = React.createClass({
           'rounded-small': true,
           'loading': this.props.loading
         })}
-        disabled={this.props.loading}>
+        disabled={this.props.loading}
+        to={this.props.href}>
         <span>{this.props.children}</span>
       </ButtonComponent>
     );

--- a/huxley/www/static/js/huxley/components/ForgotPasswordView.js
+++ b/huxley/www/static/js/huxley/components/ForgotPasswordView.js
@@ -9,7 +9,7 @@
 
 var $ = require('jquery');
 var React = require('react/addons');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var Button = require('./Button');
 var NavLink = require('./NavLink');
@@ -20,7 +20,7 @@ require('jquery-ui/effect-shake');
 var ForgotPasswordView = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
-    RRouter.RoutingContextMixin
+    Router.Navigation,
   ],
 
   getInitialState: function() {
@@ -93,7 +93,7 @@ var ForgotPasswordView = React.createClass({
   },
 
   _handleSuccess: function(data, status, jqXHR) {
-    this.navigate('/password/reset');
+    this.transitionTo('/password/reset');
   },
 
   _handleError: function(jqXHR, status, error) {

--- a/huxley/www/static/js/huxley/components/LoginView.js
+++ b/huxley/www/static/js/huxley/components/LoginView.js
@@ -11,7 +11,7 @@ var console = require('console');
 
 var $ = require('jquery');
 var React = require('react/addons');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var Button = require('./Button');
 var CurrentUserActions = require('../actions/CurrentUserActions');
@@ -23,7 +23,7 @@ require('jquery-ui/effect-shake');
 var LoginView = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
-    RRouter.RoutingContextMixin
+    Router.Navigation,
   ],
 
   getInitialState: function() {
@@ -40,7 +40,7 @@ var LoginView = React.createClass({
       return;
     }
     if (this.props.user.isAdvisor()) {
-      this.navigate('/advisor/profile');
+      this.transitionTo('/advisor/profile');
     }
   },
 

--- a/huxley/www/static/js/huxley/components/NavLink.js
+++ b/huxley/www/static/js/huxley/components/NavLink.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-var Link = require('rrouter').Link;
+var Link = require('react-router').Link;
 var React = require('react/addons');
 
 var NavLink = React.createClass({
@@ -25,7 +25,7 @@ var NavLink = React.createClass({
           'arrow-left': this.props.direction == 'left',
           'arrow-right': this.props.direction == 'right'
         })}
-        href={this.props.href}>
+        to={this.props.href}>
         {this.props.children}
       </Link>
     );

--- a/huxley/www/static/js/huxley/components/NavTab.js
+++ b/huxley/www/static/js/huxley/components/NavTab.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-var Link = require('rrouter').Link;
+var Link = require('react-router').Link;
 var React = require('react');
 
 var NavTab = React.createClass({
@@ -17,7 +17,7 @@ var NavTab = React.createClass({
 
   render: function() {
     return (
-      <Link href={this.props.href} className='tab'>
+      <Link to={this.props.href} className='tab'>
         {this.props.children}
       </Link>
     );

--- a/huxley/www/static/js/huxley/components/RedirectView.js
+++ b/huxley/www/static/js/huxley/components/RedirectView.js
@@ -8,18 +8,18 @@
 'use strict';
 
 var React = require('react');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var OuterView = require('./OuterView');
 
 var RedirectView = React.createClass({
-  mixins: [RRouter.RoutingContextMixin],
+  mixins: [Router.Navigation],
 
   componentDidMount: function() {
     if (this.props.user.isAnonymous()) {
-      this.navigate('/login');
+      this.transitionTo('/login');
     } else if (this.props.user.isAdvisor()) {
-      this.navigate('/advisor/profile');
+      this.transitionTo('/advisor/profile');
     }
   },
 

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -11,7 +11,7 @@ var console = require('console');
 
 var $ = require('jquery');
 var React = require('react/addons');
-var RRouter = require('rrouter');
+var Router = require('react-router');
 
 var Button = require('./Button');
 var ContactTypes = require('../constants/ContactTypes');
@@ -31,7 +31,7 @@ var USA = 'United States of America';
 var RegistrationView = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
-    RRouter.RoutingContextMixin
+    Router.Navigation,
   ],
 
   getInitialState: function() {
@@ -684,9 +684,9 @@ var RegistrationView = React.createClass({
 
   _handleSuccess: function(data, status, jqXHR) {
     if (data.school.waitlist) {
-      this.navigate('/register/waitlist');
+      this.transitionTo('/register/waitlist');
     } else {
-      this.navigate('/register/success');
+      this.transitionTo('/register/success');
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -5,19 +5,17 @@
   "main": "huxley/www/static/js/huxley.browserify.js",
   "license": "BSD",
   "dependencies": {
-    "browserify": "5.10.0",
-    "envify": "3.0.0",
-    "react": "0.11.1",
-    "reactify": "0.14.0",
+    "browserify": "6.3.2",
+    "envify": "3.2.0",
+    "react": "0.12.1",
+    "reactify": "0.17.1",
     "jquery": "2.1.1",
     "jquery.cookie": "1.4.1",
     "jquery-ui": "1.10.5",
     "jest-cli": "0.1.18",
-    "url-pattern": "0.6.0",
-    "bluebird": "2.1.1",
-    "rrouter": "0.4.2",
     "uglify-js": "2.4.15",
-    "es6-promise": "1.0.0"
+    "es6-promise": "2.0.0",
+    "react-router": "~0.11.1"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
This swaps out RRouter for react-router, which appears to be much
better-maintained. It also updates a bunch of JS dependencies to
their latest possible versions.

Test Plan: Go the app, verify the login view appears. Login and click
around, verify that things look reasonable.

Resolves #367, Resolves #369.
