### PR TITLE
Fix top bar animating on every page transition.

### DIFF
--- a/huxley/www/static/js/huxley/Huxley.js
+++ b/huxley/www/static/js/huxley/Huxley.js
@@ -9,6 +9,8 @@
 
 var React = require('react/addons');
 var Router = require('react-router');
+
+var AdvisorView = require('./components/AdvisorView');
 var CurrentUserStore = require('./stores/CurrentUserStore');
 
 var RouteHandler = Router.RouteHandler;
@@ -28,7 +30,18 @@ var Huxley = React.createClass({
   },
 
   render: function() {
-    return <RouteHandler user={CurrentUserStore.getCurrentUser()} />;
+    var user = CurrentUserStore.getCurrentUser();
+    if (user.isAnonymous()) {
+      return <RouteHandler user={user} />;
+    } else if (user.isAdvisor()) {
+      return (
+        <AdvisorView user={user}>
+          <RouteHandler user={user} />
+        </AdvisorView>
+      );
+    } else {
+      // TODO: Chairs
+    }
   },
 });
 

--- a/huxley/www/static/js/huxley/components/AdvisorAssignmentsView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorAssignmentsView.js
@@ -10,10 +10,10 @@
 var $ = require('jquery');
 var React = require('react');
 
-var AdvisorView = require('./AdvisorView');
 var AssignmentStore = require('../stores/AssignmentStore');
 var CommitteeStore = require('../stores/CommitteeStore');
 var CountryStore = require('../stores/CountryStore');
+var InnerView = require('./InnerView');
 
 var AdvisorAssignmentsView = React.createClass({
   getInitialState: function() {
@@ -47,7 +47,7 @@ var AdvisorAssignmentsView = React.createClass({
 
   render: function() {
     return (
-      <AdvisorView user={this.props.user}>
+      <InnerView>
         <h2>Roster</h2>
         <p>
           Here you can view your tentative assignments for BMUN 63. If you
@@ -70,7 +70,7 @@ var AdvisorAssignmentsView = React.createClass({
           </div>
           <div className="tablemenu footer" />
         </form>
-      </AdvisorView>
+      </InnerView>
     );
   },
 

--- a/huxley/www/static/js/huxley/components/AdvisorProfileView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorProfileView.js
@@ -9,9 +9,9 @@
 
 var React = require('react/addons');
 
-var AdvisorView = require('./AdvisorView');
 var Button = require('./Button');
-var InvoiceButton = require('./InvoiceButton'); 
+var InnerView = require('./InnerView');
+var InvoiceButton = require('./InvoiceButton');
 var LogoutButton = require('./LogoutButton');
 var ProgramTypes = require('../constants/ProgramTypes');
 var User = require('../User');
@@ -27,7 +27,7 @@ var AdvisorProfileView = React.createClass({
     var user = this.props.user.getData();
     var school = this.props.user.getSchool();
     return (
-      <AdvisorView user={this.props.user}>
+      <InnerView>
         <h2>Welcome, {user.first_name}!</h2>
         <p>
           We are very excited to see {school.name} at BMUN 63 this year! Here,
@@ -39,7 +39,7 @@ var AdvisorProfileView = React.createClass({
         <p>
           Advisors, if you wish to generate an invoice for your school with your
           payment details, please click on the Generate Your Invoice button under
-          the Fees tab. You will receive an invoice in your email within 2 business 
+          the Fees tab. You will receive an invoice in your email within 2 business
           days.
         </p>
         <br />
@@ -207,7 +207,7 @@ var AdvisorProfileView = React.createClass({
           <div className="tablemenu footer">
           </div>
         </form>
-      </AdvisorView>
+      </InnerView>
     );
   },
 });

--- a/huxley/www/static/js/huxley/components/AdvisorView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorView.js
@@ -11,7 +11,9 @@ var React = require('react');
 var Router = require('react-router');
 
 var InnerView = require('./InnerView');
+var NavTab = require('./NavTab');
 var PermissionDeniedView = require('./PermissionDeniedView');
+var TopBar = require('./TopBar');
 
 var AdvisorView = React.createClass ({
   mixins: [Router.Navigation],
@@ -23,24 +25,25 @@ var AdvisorView = React.createClass ({
   },
 
   render: function() {
-    if (this.props.user.isAdvisor()) {
-      return (
-        <InnerView user={this.props.user}>
-          {this.props.children}
-        </InnerView>
-      );
-    } else if (this.props.user.isChair()) {
-      return (
-        <InnerView user={this.props.user}>
-          <PermissionDeniedView />
-        </InnerView>
-      );
-    } else {
-      return (
-        <div />
-      );
-    }
-  }
+    var content = this.props.user.isAdvisor()
+      ? this.props.children
+      : <PermissionDeniedView />;
+
+    return (
+      <div>
+        <TopBar user={this.props.user} />
+        <div id="appnavbar" className="titlebar rounded-top">
+          <NavTab href="/advisor/profile">
+            Profile
+          </NavTab>
+          <NavTab href="/advisor/assignments">
+            Assignments
+          </NavTab>
+        </div>
+        {this.props.children}
+      </div>
+    );
+  },
 });
 
 module.exports = AdvisorView;

--- a/huxley/www/static/js/huxley/components/Button.js
+++ b/huxley/www/static/js/huxley/components/Button.js
@@ -28,10 +28,11 @@ var Button = React.createClass({
 
   render: function() {
     var cx = React.addons.classSet;
-    var ButtonComponent = this.props.href ? Router.Link : React.DOM.button;
+    var ButtonComponent = this.props.href ? Router.Link : 'button';
 
-    return this.transferPropsTo(
+    return (
       <ButtonComponent
+        {...this.props}
         className={cx({
           'button': true,
           'button-small': this.props.size == 'small',

--- a/huxley/www/static/js/huxley/components/InnerView.js
+++ b/huxley/www/static/js/huxley/components/InnerView.js
@@ -8,25 +8,12 @@
 'use strict';
 
 var React = require('react');
-var TopBar = require('./TopBar');
-var NavTab = require('./NavTab');
 
 var InnerView = React.createClass({
   render: function() {
     return (
-      <div>
-        <TopBar user={this.props.user} />
-        <div id="appnavbar" className="titlebar rounded-top">
-          <NavTab href="/advisor/profile">
-            Profile
-          </NavTab>
-          <NavTab href="/advisor/assignments">
-            Assignments
-          </NavTab>
-        </div>
-        <div className="content transparent ie-layout rounded-bottom">
-          {this.props.children}
-        </div>
+      <div className="content transparent ie-layout rounded-bottom">
+        {this.props.children}
       </div>
     );
   },

--- a/huxley/www/static/js/huxley/components/LogoutButton.js
+++ b/huxley/www/static/js/huxley/components/LogoutButton.js
@@ -44,13 +44,11 @@ var LogoutButton = React.createClass({
   },
 
   _handleLogoutSuccess: function(data, status, jqXHR) {
-    console.log('logging out');
     CurrentUserActions.logout();
   },
 
   _handleLogoutError: function(jqXHR, status, error) {
     var response = jqXHR.responseJSON;
-    console.log(response.detail);
   }
 });
 

--- a/huxley/www/static/js/huxley/components/OuterView.js
+++ b/huxley/www/static/js/huxley/components/OuterView.js
@@ -11,7 +11,7 @@ var React = require('react');
 
 var OuterView = React.createClass({
   propTypes: {
-    header: React.PropTypes.component
+    header: React.PropTypes.element,
   },
 
   render: function() {

--- a/huxley/www/static/js/huxley/components/RegistrationClosedView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationClosedView.js
@@ -16,7 +16,7 @@ var RegistrationClosedView = React.createClass({
   render: function() {
     return (
       <OuterView>
-        <div class="letter">
+        <div className="letter">
           <h1>I'm Sorry</h1>
           <p>
             Thank you for your interest in participating in the sixty-third


### PR DESCRIPTION
This fixes the top bar animating on every page transition by moving it out of InnerView, and instead making AdvisorView a wrapper component. This way, when the page transitions, AdvisorView doesn't unmount (only its child view swaps out).

This also fixes a couple of small bugs and/or style issues.

Test Plan: Login, change views, verify it works and the top bar doesn't animate repeatedly.
