### PR TITLE
Regclose

### DIFF
--- a/huxley/api/tests/test_user.py
+++ b/huxley/api/tests/test_user.py
@@ -254,6 +254,7 @@ class UserListGetTestCase(ListAPITestCase):
              'school': user2.school_id,
              'committee': user2.committee_id}])
 
+
 @override_settings(REGISTRATION_OPEN=True)
 class UserListPostTestCase(CreateAPITestCase):
     url_name = 'api:user_list'

--- a/huxley/api/tests/test_user.py
+++ b/huxley/api/tests/test_user.py
@@ -6,6 +6,7 @@ import json
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
+from django.test.utils import override_settings
 
 from huxley.accounts.models import User
 from huxley.api.tests import (CreateAPITestCase, DestroyAPITestCase,
@@ -253,7 +254,7 @@ class UserListGetTestCase(ListAPITestCase):
              'school': user2.school_id,
              'committee': user2.committee_id}])
 
-
+@override_settings(REGISTRATION_OPEN=True)
 class UserListPostTestCase(CreateAPITestCase):
     url_name = 'api:user_list'
     params = {'username': 'Kunal',
@@ -324,6 +325,13 @@ class UserListPostTestCase(CreateAPITestCase):
         response = self.get_response(params=self.get_params(password='pass'))
         self.assertEqual(response.data, {
             'password': ['Password must be at least 6 characters.']})
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_invalid(self):
+        params = self.get_params()
+        response = self.get_response(params)
+        self.assertEqual(response.data, {
+            'detail': 'Conference registration is closed.'})
 
 
 class CurrentUserTestCase(TestCase):

--- a/huxley/api/views/user.py
+++ b/huxley/api/views/user.py
@@ -17,16 +17,20 @@ from huxley.api.permissions import IsPostOrSuperuserOnly, IsUserOrSuperuser
 from huxley.api.serializers import CreateUserSerializer, UserSerializer
 from huxley.core.models import School
 
+
 class UserList(generics.ListCreateAPIView):
     authentication_classes = (SessionAuthentication,)
     queryset = User.objects.all()
     permission_classes = (IsPostOrSuperuserOnly,)
 
+    def create(self, request, *args, **kwargs):
+        if settings.REGISTRATION_OPEN:
+            return super(UserList, self).create(request, args, kwargs)
+        raise PermissionDenied('Conference registration is closed.')
+
     def get_serializer_class(self):
         if self.request.method == 'POST':
-            if settings.REGISTRATION_OPEN:
-                return CreateUserSerializer
-            raise PermissionDenied('Conference registration is closed.')
+            return CreateUserSerializer
         return UserSerializer
 
 

--- a/huxley/api/views/user.py
+++ b/huxley/api/views/user.py
@@ -25,7 +25,7 @@ class UserList(generics.ListCreateAPIView):
 
     def create(self, request, *args, **kwargs):
         if settings.REGISTRATION_OPEN:
-            return super(UserList, self).create(request, args, kwargs)
+            return super(UserList, self).create(request, *args, **kwargs)
         raise PermissionDenied('Conference registration is closed.')
 
     def get_serializer_class(self):

--- a/huxley/api/views/user.py
+++ b/huxley/api/views/user.py
@@ -24,7 +24,8 @@ class UserList(generics.ListCreateAPIView):
 
     def get_serializer_class(self):
         if self.request.method == 'POST':
-            return CreateUserSerializer
+            # return CreateUserSerializer
+            raise PermissionDenied('Conference registration is closed.')
         return UserSerializer
 
 

--- a/huxley/api/views/user.py
+++ b/huxley/api/views/user.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
+from django.conf import settings
 from django.contrib.auth import login, logout
 from django.http import Http404
 
@@ -16,7 +17,6 @@ from huxley.api.permissions import IsPostOrSuperuserOnly, IsUserOrSuperuser
 from huxley.api.serializers import CreateUserSerializer, UserSerializer
 from huxley.core.models import School
 
-
 class UserList(generics.ListCreateAPIView):
     authentication_classes = (SessionAuthentication,)
     queryset = User.objects.all()
@@ -24,7 +24,8 @@ class UserList(generics.ListCreateAPIView):
 
     def get_serializer_class(self):
         if self.request.method == 'POST':
-            # return CreateUserSerializer
+            if settings.REGISTRATION_OPEN:
+                return CreateUserSerializer
             raise PermissionDenied('Conference registration is closed.')
         return UserSerializer
 

--- a/huxley/settings/__init__.py
+++ b/huxley/settings/__init__.py
@@ -5,6 +5,7 @@ from .conference import *
 from .main import *
 from .logging import *
 from .pipeline import *
+from .registration import *
 
 try:
     from .local import *

--- a/huxley/settings/registration.py
+++ b/huxley/settings/registration.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2011-2014 Berkeley Model United Nations. All rights reserved.
+# Use of this source code is governed by a BSD License (see LICENSE).
+
+REGISTRATION_OPEN = False


### PR DESCRIPTION
Closed registration on the backend. Created a setting that was true if registration is open. When registration is closed set the setting to false which raises a PermissionDenied error in huxley/api/views/user.py when trying to create a user. Updated the unit tests accordingly by overriding the setting, and also created a unit test to test for closed registration.