### PR TITLE
#46 updated DatabaseHandler and registered LogEntry to admin panel.

### DIFF
--- a/huxley/logs/admin.py
+++ b/huxley/logs/admin.py
@@ -1,3 +1,7 @@
-from django.contrib import admin
+# Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
+# Use of this source code is governed by a BSD License (see LICENSE).
 
-# Register your models here.
+from django.contrib import admin
+from huxley.logs.models import LogEntry
+
+admin.site.register(LogEntry)

--- a/huxley/logs/handlers.py
+++ b/huxley/logs/handlers.py
@@ -15,7 +15,7 @@ class DatabaseHandler(logging.Handler):
         try:
             log_entry = LogEntry(
                 level=record.levelname,
-                message=record.message,
+                message=record.msg,
                 timestamp=datetime.datetime.now())
             log_entry.save()
         except:


### PR DESCRIPTION
In the DatabaseHandler object an error was occurring every time an exception was being logged to the database because apparently the LogRecord object has no attribute "message". I think the reason why is because Formatter.format() hadn't been invoked and/or because there were no "args". So I used the attribute "msg" instead (for reference: https://docs.python.org/2/library/logging.html#logrecord-attributes). To verify exceptions were being logged I also registered the LogEntry model to the admin panel and checked on the admin panel that exceptions were being logged in the LogEntry column of the database and they were. We should probably write some Unit Tests for the LogEntry model and for the DatabaseHandler as well.