### PR TITLE
Use standard flux in AssignmentStore.

### DIFF
--- a/huxley/www/static/js/huxley/stores/AssignmentStore.js
+++ b/huxley/www/static/js/huxley/stores/AssignmentStore.js
@@ -7,12 +7,14 @@
 
 var $ = require('jquery');
 var Promise = require('es6-promise').Promise;
+var Dispatcher = require('../dispatcher/Dispatcher');
+var {Store} = require('flux/utils');
 
 
 var _assignmentPromise = null;
 
-var AssignmentStore = {
-  getAssignments: function(schoolID, callback) {
+class AssignmentStore extends Store {
+  getAssignments(schoolID, callback) {
     if (!_assignmentPromise) {
       _assignmentPromise = new Promise(function(resolve, reject) {
         $.ajax({
@@ -27,7 +29,12 @@ var AssignmentStore = {
     }
 
     _assignmentPromise.then(callback);
-  },
+  }
+
+  __onDispatch(action) {
+    // This method must be overwritten
+    return;
+  }
 };
 
-module.exports = AssignmentStore;
+module.exports = new AssignmentStore(Dispatcher);

--- a/huxley/www/static/js/huxley/stores/CommitteeStore.js
+++ b/huxley/www/static/js/huxley/stores/CommitteeStore.js
@@ -7,12 +7,14 @@
 
 var $ = require('jquery');
 var Promise = require('es6-promise').Promise;
+var Dispatcher = require('../dispatcher/Dispatcher');
+var {Store} = require('flux/utils');
 
 
 var _committeePromise = null;
 
-var CommitteeStore = {
-  getCommittees: function(callback) {
+class CommitteeStore extends Store {
+  getCommittees(callback) {
     if (!_committeePromise) {
       _committeePromise = new Promise(function(resolve, reject) {
         $.ajax({
@@ -27,15 +29,20 @@ var CommitteeStore = {
     }
 
     _committeePromise.then(callback);
-  },
+  }
 
-  getSpecialCommittees: function(callback) {
+  getSpecialCommittees(callback) {
     this.getCommittees(function(committees) {
       callback(committees.filter(function(committee) {
         return committee.special;
       }));
     });
   }
+
+  __onDispatch(action) {
+    // This method must be overwritten
+    return;
+  }
 };
 
-module.exports = CommitteeStore;
+module.exports = new CommitteeStore(Dispatcher);

--- a/huxley/www/static/js/huxley/stores/CountryStore.js
+++ b/huxley/www/static/js/huxley/stores/CountryStore.js
@@ -7,12 +7,14 @@
 
 var $ = require('jquery');
 var Promise = require('es6-promise').Promise;
+var Dispatcher = require('../dispatcher/Dispatcher');
+var {Store} = require('flux/utils');
 
 
 var _countryPromise = null;
 
-var CountryStore = {
-  getCountries: function(callback) {
+class CountryStore extends Store {
+  getCountries(callback) {
     if (!_countryPromise) {
       _countryPromise = new Promise(function(resolve, reject) {
         $.ajax({
@@ -27,7 +29,12 @@ var CountryStore = {
     }
 
     _countryPromise.then(callback);
-  },
+  }
+
+  __onDispatch(action) {
+    // This method must be overwritten
+    return;
+  }
 };
 
-module.exports = CountryStore;
+module.exports = new CountryStore(Dispatcher);

--- a/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
@@ -16,12 +16,17 @@ describe('AssignmentStore', function() {
   beforeEach(function() {
     $ = require('jquery');
     AssignmentStore = require('../AssignmentStore');
+    Dispatcher = require('../../dispatcher/Dispatcher');
 
     mockAssignments = [{id: 1, school: 1}, {id: 2, school: 1}];
 
     $.ajax.mockImplementation(function(options) {
       options.success(null, null, {responseJSON: mockAssignments});
     });
+  });
+
+  it('subscribes to the dispatcher', function() {
+    expect(Dispatcher.register).toBeCalled();
   });
 
   it('requests the assignments on first call and caches locally', function() {

--- a/huxley/www/static/js/huxley/stores/__tests__/CommitteeStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/CommitteeStore-test.js
@@ -18,6 +18,7 @@ describe('CommitteeStore', function() {
   beforeEach(function() {
     $ = require('jquery');
     CommitteeStore = require('../CommitteeStore');
+    Dispatcher = require('../../dispatcher/Dispatcher');
 
     disc = {id: 1, name: 'DISC', special: false};
     icj = {id: 2, name: 'ICJ', special: true};
@@ -26,6 +27,10 @@ describe('CommitteeStore', function() {
     $.ajax.mockImplementation(function(options) {
       options.success(null, null, {responseJSON: mockCommittees});
     });
+  });
+
+  it('subscribes to the dispatcher', function() {
+    expect(Dispatcher.register).toBeCalled();
   });
 
   it('requests the committees on first call and caches locally', function() {

--- a/huxley/www/static/js/huxley/stores/__tests__/CountryStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/CountryStore-test.js
@@ -16,11 +16,16 @@ describe('CountryStore', function() {
   beforeEach(function() {
     $ = require('jquery');
     CountryStore = require('../CountryStore');
+    Dispatcher = require('../../dispatcher/Dispatcher');
 
     mockCountries = [{id: 1, name: 'USA'}, {id: 2, name: 'China'}];
     $.ajax.mockImplementation(function(options) {
       options.success(null, null, {responseJSON: mockCountries});
     });
+  });
+
+  it('subscribes to the dispatcher', function() {
+    expect(Dispatcher.register).toBeCalled();
   });
 
   it('requests the countries on first call and caches locally', function() {


### PR DESCRIPTION
Transitions to standard flux in the AssignmentStore. If this looks good, I'm gonna follow the same logic for the other remaining stores.

Only consideration is that since we must overwrite the callback that gets registered to the dispatcher in the store, do we want to use actions to call our functions like getAssignments? Not really sure what the benefit of doing that would be or if those benefits are worth the effort. 