### PR TITLE
#353 does not fail emails silently.

### DIFF
--- a/huxley/core/middlewares.py
+++ b/huxley/core/middlewares.py
@@ -15,8 +15,7 @@ class ExceptionLoggerMiddleware(object):
               'uri': request.path,
               'status_code': 500,
               'username': request.user.username})
-        logger.error(log)
-        logger.exception(exception)
+        logger.exception(log)
 
 
 class LoggingMiddleware(object):

--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -198,7 +198,7 @@ class School(models.Model):
             send_mail('Registration Comments from '+ school.name, school.name +
                 ' made comments about registration: '
                 + school.registration_comments, 'tech@bmun.org',
-                ['external@bmun.org'], fail_silently=True)
+                ['external@bmun.org'], fail_silently=False)
 
     @classmethod
     def email_confirmation(cls, **kwargs):
@@ -213,7 +213,7 @@ class School(models.Model):
                           'For all other questions, please email info@bmun.org.\n\n'
                           'Thank you for using Huxley!' % conference.session,
                           'no-reply@bmun.org',
-                          [school.primary_email], fail_silently=True)
+                          [school.primary_email], fail_silently=False)
             else:
                 registration_fee = conference.registration_fee
                 delegate_fee = conference.delegate_fee
@@ -228,7 +228,7 @@ class School(models.Model):
                           'For all other questions, please email info@bmun.org.\n\n'
                           'Thank you for using Huxley!' % (conference.session, int(registration_fee), int(delegate_fee)),
                           'no-reply@bmun.org',
-                          [school.primary_email], fail_silently=True)
+                          [school.primary_email], fail_silently=False)
 
     def __unicode__(self):
         return self.name

--- a/huxley/logging/mail.py
+++ b/huxley/logging/mail.py
@@ -34,7 +34,7 @@ class LoggingEmailBackend(smtp.EmailBackend):
                           'uri': ', '.join(email.to),
                           'status_code': 500,
                           'username': ''})
-                    logger.error(log)
+                    logger.exception(log)
 
 
 def log_email(email):


### PR DESCRIPTION
Should we only catch SMTPExceptions or should we catch exceptions more generically in case emails fail for another reason (like a bug in our own code or something like that)? Also not having the failure be emailed to tech in case the exception has to do with something on our side not allowing us to send emails. In that case we would get another exception when we failed to send the email to tech. However that email would fail for the same reason causing yet another exception to be generated, logged and attempted to be emailed to tech, but it would fail as well. This behavior would continue until we hit the bottom of the stack. To avoid this behavior I'm just having it log and not email.