### PR TITLE
Fix Spanish speaking & Chinese speaking delegate issue

### DIFF
--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -81,7 +81,6 @@ class SchoolSerializer(serializers.ModelSerializer):
         advanced_delegates = data.get('advanced_delegates')
         spanish_speaking_delegates = data.get('spanish_speaking_delegates')
         chinese_speaking_delegates = data.get('chinese_speaking_delegates')
-        total_delegates = beginner_delegates + intermediate_delegates + advanced_delegates
 
         if primary_phone:
             try:
@@ -99,6 +98,14 @@ class SchoolSerializer(serializers.ModelSerializer):
                     validators.phone_domestic(secondary_phone)
             except serializers.ValidationError:
                 invalid_fields['secondary_phone'] = 'This is an invalid phone number.'
+
+        total_delegates = 0
+        if beginner_delegates:
+            total_delegates += beginner_delegates
+        if intermediate_delegates:
+            total_delegates += intermediate_delegates
+        if advanced_delegates:
+            total_delegates += advanced_delegates
 
         if spanish_speaking_delegates > total_delegates:
             invalid_fields['spanish_speaking_delegates'] = 'Cannot exceed total delegates'

--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -72,20 +72,42 @@ class SchoolSerializer(serializers.ModelSerializer):
 
 
     def validate(self, data):
+        invalid_fields = {}
         international = data.get('international')
         primary_phone = data.get('primary_phone')
         secondary_phone = data.get('secondary_phone')
+        beginner_delegates = data.get('beginner_delegates')
+        intermediate_delegates = data.get('intermediate_delegates')
+        advanced_delegates = data.get('advanced_delegates')
+        spanish_speaking_delegates = data.get('spanish_speaking_delegates')
+        chinese_speaking_delegates = data.get('chinese_speaking_delegates')
+        total_delegates = beginner_delegates + intermediate_delegates + advanced_delegates
 
         if primary_phone:
-            if international:
-                validators.phone_international(primary_phone)
-            else:
-                validators.phone_domestic(primary_phone)
+            try:
+                if international:
+                    validators.phone_international(primary_phone)
+                else:
+                    validators.phone_domestic(primary_phone)
+            except ValidationError:
+                invalid_fields['Primary Phone'] = 'Invalid phone number'
         if secondary_phone:
-            if international:
-                validators.phone_international(secondary_phone)
-            else:
-                validators.phone_domestic(secondary_phone)
+            try:
+                if international:
+                    validators.phone_international(secondary_phone)
+                else:
+                    validators.phone_domestic(secondary_phone)
+                except ValidationError:
+                    invalid_fields['Secondary Phone'] = "Invalid phone number"
+
+        if spanish_speaking_delegates > total_delegates:
+            invalid_fields['Spanish Speaking Delegates'] = 'Cannot exceed total delegates'
+        if chinese_speaking_delegates > total_delegates:
+            invalid_fields['Chinese Speaking Delegates'] = 'Cannont exeed total delegates'
+
+        if invalid_fields:
+            error_message = [field + ": " + invalid_fields[field] for field in invalid_fields].join('\n');
+            raise ValidationError(error_message)
 
         return data
 

--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -89,25 +89,24 @@ class SchoolSerializer(serializers.ModelSerializer):
                     validators.phone_international(primary_phone)
                 else:
                     validators.phone_domestic(primary_phone)
-            except ValidationError:
-                invalid_fields['Primary Phone'] = 'Invalid phone number'
+            except serializers.ValidationError:
+                invalid_fields['primary_phone'] = 'This is an invalid phone number'
         if secondary_phone:
             try:
                 if international:
                     validators.phone_international(secondary_phone)
                 else:
                     validators.phone_domestic(secondary_phone)
-                except ValidationError:
-                    invalid_fields['Secondary Phone'] = "Invalid phone number"
+            except serializers.ValidationError:
+                invalid_fields['secondary_phone'] = 'This is an invalid phone number'
 
         if spanish_speaking_delegates > total_delegates:
-            invalid_fields['Spanish Speaking Delegates'] = 'Cannot exceed total delegates'
+            invalid_fields['spanish_speaking_delegates'] = 'Cannot exceed total delegates'
         if chinese_speaking_delegates > total_delegates:
-            invalid_fields['Chinese Speaking Delegates'] = 'Cannont exeed total delegates'
+            invalid_fields['chinese_speaking_delegates'] = 'Cannot exceed total delegates'
 
         if invalid_fields:
-            error_message = [field + ": " + invalid_fields[field] for field in invalid_fields].join('\n');
-            raise ValidationError(error_message)
+            raise serializers.ValidationError(invalid_fields)
 
         return data
 

--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -93,11 +93,11 @@ class SchoolSerializer(serializers.ModelSerializer):
             else:
                 validators.phone_domestic(phone)
 
-        try:
-            validate_phone(primary_phone, international)
-        except serializers.ValidationError:
-            invalid_fields['primary_phone'] = 'This is an invalid phone number.'
-        
+        if primary_phone:
+            try:
+                validate_phone(primary_phone, international)
+            except serializers.ValidationError:
+                invalid_fields['primary_phone'] = 'This is an invalid phone number.'
         if secondary_phone:
             try:
                 validate_phone(secondary_phone, international)

--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -90,7 +90,7 @@ class SchoolSerializer(serializers.ModelSerializer):
                 else:
                     validators.phone_domestic(primary_phone)
             except serializers.ValidationError:
-                invalid_fields['primary_phone'] = 'This is an invalid phone number'
+                invalid_fields['primary_phone'] = 'This is an invalid phone number.'
         if secondary_phone:
             try:
                 if international:
@@ -98,7 +98,7 @@ class SchoolSerializer(serializers.ModelSerializer):
                 else:
                     validators.phone_domestic(secondary_phone)
             except serializers.ValidationError:
-                invalid_fields['secondary_phone'] = 'This is an invalid phone number'
+                invalid_fields['secondary_phone'] = 'This is an invalid phone number.'
 
         if spanish_speaking_delegates > total_delegates:
             invalid_fields['spanish_speaking_delegates'] = 'Cannot exceed total delegates'

--- a/huxley/api/tests/__init__.py
+++ b/huxley/api/tests/__init__.py
@@ -97,7 +97,7 @@ class AbstractAPITestCase(APITestCase):
 
     def assertInvalidPhone(self, response, field):
         self.assertEqual(response.data, {
-            u'non_field_errors': [u'This is an invalid phone number.']})
+            '%s' % field: [u'This is an invalid phone number.']})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -704,7 +704,7 @@ var RegistrationView = React.createClass({
     if (!response) {
       return;
     }
-    console.log(response)
+
     this.setState({
       errors: response,
       loading: false

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -109,7 +109,7 @@ var RegistrationView = React.createClass({
           onSubmit={this._handleSubmit}>
           <div>
             <h1>Register for Berkeley Model United Nations</h1>
-            <p>Please fill out the following information to register your school
+            <p>Pleasee fill out the following information to register your school
             for BMUN {conference.session}. All fields are required except for Secondary Contact
             information. Please note that BMUN is a high school level conference.</p>
             <NavLink direction="left" href="/login">
@@ -367,6 +367,8 @@ var RegistrationView = React.createClass({
               <li>
                 <input
                   type="text"
+                  id="input_delegates"
+                  name="input_delegates"
                   placeholder="Number of Chinese Speaking Delegates"
                   valueLink={this.linkState('chinese_speaking_delegates')}
                 />
@@ -525,6 +527,13 @@ var RegistrationView = React.createClass({
       return (
         <label className="hint error">
           {this.state.errors.school[field]}
+        </label>
+      );
+    } else if (this.state.errors.school && 
+               this.state.errors.school['non_field_errors']) {
+      return (
+        <label className="hint error" >
+          {this.state.errors.school['non_field_errors']}
         </label>
       );
     }

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -529,13 +529,6 @@ var RegistrationView = React.createClass({
           {this.state.errors.school[field]}
         </label>
       );
-    } else if (this.state.errors.school && 
-               this.state.errors.school['non_field_errors']) {
-      return (
-        <label className="hint error" >
-          {this.state.errors.school['non_field_errors']}
-        </label>
-      );
     }
 
     return null;
@@ -711,7 +704,7 @@ var RegistrationView = React.createClass({
     if (!response) {
       return;
     }
-
+    console.log(response)
     this.setState({
       errors: response,
       loading: false

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -109,7 +109,7 @@ var RegistrationView = React.createClass({
           onSubmit={this._handleSubmit}>
           <div>
             <h1>Register for Berkeley Model United Nations</h1>
-            <p>Pleasee fill out the following information to register your school
+            <p>Please fill out the following information to register your school
             for BMUN {conference.session}. All fields are required except for Secondary Contact
             information. Please note that BMUN is a high school level conference.</p>
             <NavLink direction="left" href="/login">
@@ -367,8 +367,6 @@ var RegistrationView = React.createClass({
               <li>
                 <input
                   type="text"
-                  id="input_delegates"
-                  name="input_delegates"
                   placeholder="Number of Chinese Speaking Delegates"
                   valueLink={this.linkState('chinese_speaking_delegates')}
                 />


### PR DESCRIPTION
This modifies the SchoolSerializer's validate method to collect all validation issues into a single ValidationError with a dict of every field checked by the method with an issue. It introduces a check on whether the # of Spanish or Chinese speaking delegates exceeds the total # of delegates, as well as fix a bug where an invalid phone number, e.g. (123) 456 78, would raise a ValidationError but the error would not appear in registration view.