### PR TITLE
AutoTest: Introduce User named tuple.

### DIFF
--- a/huxley/api/tests/auto.py
+++ b/huxley/api/tests/auto.py
@@ -1,14 +1,22 @@
 # Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
+from collections import namedtuple
+
 from django.db import models
 from rest_framework import serializers
 
 from huxley.api.tests import RetrieveAPITestCase
 
 
+User = namedtuple('User', ['username', 'password', 'expected_error'])
+User.__new__.__defaults__ = (None, None, None)
+
+
+EXP_NOT_AUTHENTICATED = 'exp_not_authenticated'
+
+
 class RetrieveAPIAutoTestCase(RetrieveAPITestCase):
-    NOT_AUTHENTICATED = 'not_authenticated'
 
     @classmethod
     def get_test_object(cls):
@@ -30,7 +38,7 @@ class RetrieveAPIAutoTestCase(RetrieveAPITestCase):
                 self.client.login(username=username, password=password)
             response = self.get_response(self.object.id)
 
-            if expected_error == self.NOT_AUTHENTICATED:
+            if expected_error == EXP_NOT_AUTHENTICATED:
                 self.assertNotAuthenticated(response)
             else:
                 self.assert_response(response)

--- a/huxley/api/tests/school/test_school.py
+++ b/huxley/api/tests/school/test_school.py
@@ -21,9 +21,9 @@ class SchoolDetailGetTestCase(auto.RetrieveAPIAutoTestCase):
     def get_users(cls, test_object):
         TestUsers.new_superuser(username='user1', password='user1')
         return (
-            (None, None, cls.NOT_AUTHENTICATED),
-            (test_object.advisor.username, 'test', None),
-            ('user1', 'user1', None),
+            auto.User(expected_error=auto.EXP_NOT_AUTHENTICATED),
+            auto.User(username=test_object.advisor.username, password='test'),
+            auto.User(username='user1', password='user1'),
         )
 
 

--- a/huxley/api/tests/test_assignment.py
+++ b/huxley/api/tests/test_assignment.py
@@ -22,9 +22,9 @@ class AssignmentDetailGetTestCase(auto.RetrieveAPIAutoTestCase):
     def get_users(cls, test_object):
         TestUsers.new_superuser(username='superuser', password='superuser')
         return (
-            (None, None, cls.NOT_AUTHENTICATED),
-            ('user', 'user', None),
-            ('superuser', 'superuser', None),
+            auto.User(expected_error=auto.EXP_NOT_AUTHENTICATED),
+            auto.User(username='user', password='user'),
+            auto.User(username='superuser', password='superuser'),
         )
 
 

--- a/huxley/api/tests/test_committee.py
+++ b/huxley/api/tests/test_committee.py
@@ -18,7 +18,7 @@ class CommitteeDetailGetTestCase(auto.RetrieveAPIAutoTestCase):
     @classmethod
     def get_users(cls, test_object):
         return (
-            (None, None, None),
+            auto.User(),
         )
 
 

--- a/huxley/api/tests/test_country.py
+++ b/huxley/api/tests/test_country.py
@@ -18,7 +18,7 @@ class CountryDetailGetTestCase(auto.RetrieveAPIAutoTestCase):
     @classmethod
     def get_users(cls, test_object):
         return (
-            (None, None, None),
+            auto.User(),
         )
 
 

--- a/huxley/api/tests/test_delegate.py
+++ b/huxley/api/tests/test_delegate.py
@@ -23,9 +23,9 @@ class DelegateDetailGetTestCase(auto.RetrieveAPIAutoTestCase):
     def get_users(cls, test_object):
         TestUsers.new_superuser(username='superuser', password='superuser')
         return (
-            (None, None, cls.NOT_AUTHENTICATED),
-            ('user', 'user', None),
-            ('superuser', 'superuser', None),
+            auto.User(expected_error=auto.EXP_NOT_AUTHENTICATED),
+            auto.User(username='user', password='user'),
+            auto.User(username='superuser', password='superuser'),
         )
 
 


### PR DESCRIPTION
(#475) The tuples used to specify users and expected errors were really confusing. We can use named tuples to make this more clear. We can also add some hackery so that the fields are optional (and set to None by default).