### PR TITLE
Delegate name finalization functionality (#480)

### DIFF
--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -10,6 +10,7 @@ class SchoolSerializer(serializers.ModelSerializer):
     fees_owed = serializers.FloatField(read_only=True)
     fees_paid = serializers.FloatField(read_only=True)
     assignments_finalized = serializers.BooleanField(required=False)
+    delegate_names_finalized = serializers.BooleanField(required=False)
     countrypreferences = serializers.ListField(child=serializers.IntegerField(required=False), source='country_preference_ids')
     committeepreferences = serializers.PrimaryKeyRelatedField(allow_empty=True, many=True, queryset=Committee.objects.all(), required=False)
 
@@ -49,6 +50,7 @@ class SchoolSerializer(serializers.ModelSerializer):
             'fees_owed',
             'fees_paid',
             'assignments_finalized',
+            'delegate_names_finalized',
         )
         extra_kwargs = {
         'committeepreferences': {'required': False},

--- a/huxley/api/tests/school/test_create_school.py
+++ b/huxley/api/tests/school/test_create_school.py
@@ -31,6 +31,7 @@ class CreateSchoolTestCase(CreateAPITestCase):
         'chinese_speaking_delegates': 0,
         'countrypreferences': [1, 2],
         'assignments_finalized': False,
+        'delegate_names_finalized': False,
     }
 
     def test_empty_fields(self):
@@ -124,6 +125,7 @@ class CreateSchoolTestCase(CreateAPITestCase):
             'fees_owed': float(school.fees_owed),
             'fees_paid': float(school.fees_paid),
             'assignments_finalized': school.assignments_finalized,
+            'delegate_names_finalized': school.delegate_names_finalized,
         })
 
     def test_country_preferences(self):

--- a/huxley/api/tests/test_user.py
+++ b/huxley/api/tests/test_user.py
@@ -99,6 +99,7 @@ class UserDetailGetTestCase(RetrieveAPITestCase):
                 'fees_owed': float(school.fees_owed),
                 'fees_paid': float(school.fees_paid),
                 'assignments_finalized': school.assignments_finalized,
+                'delegate_names_finalized': school.delegate_names_finalized,
             },
             'committee': user.committee_id})
 
@@ -432,4 +433,5 @@ class CurrentUserTestCase(TestCase):
             u'fees_owed': float(school.fees_owed),
             u'fees_paid': float(school.fees_paid),
             u'assignments_finalized': school.assignments_finalized,
+            u'delegate_names_finalized': school.delegate_names_finalized,
         })

--- a/huxley/core/migrations/0013_school_delegate_names_finalized.py
+++ b/huxley/core/migrations/0013_school_delegate_names_finalized.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0012_remove_school_balance'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='school',
+            name='delegate_names_finalized',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -117,7 +117,8 @@ class School(models.Model):
 
     registration_comments = models.TextField(default='', blank=True)
 
-    assignments_finalized = models.BooleanField(default=False)
+    assignments_finalized    = models.BooleanField(default=False)
+    delegate_names_finalized = models.BooleanField(default=False)
 
     fees_owed = models.DecimalField(max_digits=6, decimal_places=2, default=Decimal('0.00'))
     fees_paid = models.DecimalField(max_digits=6, decimal_places=2, default=Decimal('0.00'))

--- a/huxley/www/static/js/huxley/components/AdvisorAssignmentsView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorAssignmentsView.js
@@ -75,7 +75,7 @@ var AdvisorAssignmentsView = React.createClass({
           would like to request more slots, please email <a href="mailto:info@bmun.org">
           info@bmun.org</a>. In the coming months
           we will ask that you finalize your assignment roster and input your
-          delegates' names.
+          delegates names.
         </p>
         <form>
           <div className="tablemenu header" />

--- a/huxley/www/static/js/huxley/stores/CurrentUserStore.js
+++ b/huxley/www/static/js/huxley/stores/CurrentUserStore.js
@@ -23,9 +23,14 @@ class CurrentUserStore extends Store {
     return this._currentUser;
   }
 
-  getFinalized() {
+  getAssignmentFinalized() {
     this._assertBootstrapped();
     return this._currentUser.school.assignments_finalized;
+  }
+
+  getDelegateNameFinalized() {
+    this._assertBootstrapped();
+    return this._currentUser.school.delegate_names_finalized;
   }
 
   addListener(callback) {


### PR DESCRIPTION
See #480 for context

For what's still left to do we need to:

1. Load the delegates for that particular school from the DelegateStore in #468 
2. Render those delegates in drop downs on the UI
 * To do this it might be worth abstracting the current CountrySelect component into a general Select component because we'll want to reuse the functionality of not selecting an option more than once.
 * Assuming this first diff is good, that will be my next focus
3. Make a request to the Delegate API to assign assignments to each delegate
 * Might be good to do some validation here as well to ensure no delegate is assigned to more than one assignment and that a double delegate assignment has exactly two delegates