### PR TITLE
Switch to Webpack for JS.

### DIFF
--- a/fabfile/deploy.py.default
+++ b/fabfile/deploy.py.default
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
+# Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
 from fabric.api import cd, hosts, prefix, run, task
@@ -25,6 +25,7 @@ def deploy(environment):
         run('npm install')
         run('python manage.py migrate')
         run('git clean -xf *.css')
+        run('NODE_ENV=production ./node_modules/.bin/webpack --progress')
         run('python manage.py collectstatic --clear --noinput')
         run('../apache2/bin/restart')
 

--- a/huxley/settings/local.py.default
+++ b/huxley/settings/local.py.default
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2013 Berkeley Model United Nations. All rights reserved.
+# Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
 # These are the settings that will be different for your production deployment.
@@ -33,7 +33,3 @@ EMAIL_HOST_USER = 'email_host_user'         # Username for the mail server.
 EMAIL_HOST_PASSWORD = 'email_host_password' # Password
 DEFAULT_FROM_EMAIL = 'default_from_email'   # Default email for the From: field.
 SERVER_EMAIL = 'server_email'               # Inbox on the server.
-
-if not DEBUG:
-    from .pipeline import PIPELINE
-    PIPELINE['BROWSERIFY_BINARY'] = 'NODE_ENV=production ' + PIPELINE['BROWSERIFY_BINARY']

--- a/huxley/settings/pipeline.py
+++ b/huxley/settings/pipeline.py
@@ -1,19 +1,13 @@
 # Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
-from os.path import join
-
-from .roots import JS_ROOT, PROJECT_ROOT
-
 
 PIPELINE = {
     'COMPILERS': (
         'huxley.utils.pipeline.PySCSSCompiler',
-        'huxley.utils.pipeline.BrowserifyCompiler',
     ),
 
     'CSS_COMPRESSOR': 'pipeline.compressors.cssmin.CSSMinCompressor',
-    'JS_COMPRESSOR': 'pipeline.compressors.uglifyjs.UglifyJSCompressor',
 
     'STYLESHEETS': {
         'huxley': {
@@ -24,19 +18,4 @@ PIPELINE = {
             'output_filename': 'css/huxley.css',
         },
     },
-
-    'JAVASCRIPT': {
-        'huxley': {
-            'source_filenames': (
-                'js/huxley.browserify.js',
-            ),
-            'output_filename': 'js/huxley.js',
-        },
-    },
-
-    'UGLIFYJS_BINARY': join(PROJECT_ROOT, 'node_modules/.bin/uglifyjs'),
-    'UGLIFYJS_ARGUMENTS': '--compress --mangle --screw-ie8',
-
-    'BROWSERIFY_BINARY': join(PROJECT_ROOT, 'node_modules/.bin/browserify'),
-    'BROWSERIFY_ARGUMENTS': '-t babelify -t [detachkify -relativeTo %s]' % JS_ROOT,
 }

--- a/huxley/utils/pipeline.py
+++ b/huxley/utils/pipeline.py
@@ -7,7 +7,6 @@ from os.path import dirname
 
 from django.conf import settings
 from pipeline.compilers import SubProcessCompiler
-from pipeline_browserify.compiler import BrowserifyCompiler as BrowserifyCompilerBase
 
 
 class PySCSSCompiler(SubProcessCompiler):
@@ -24,16 +23,3 @@ class PySCSSCompiler(SubProcessCompiler):
             outfile,
         )
         return self.execute_command(command, cwd=dirname(infile))
-
-
-class BrowserifyCompiler(BrowserifyCompilerBase):
-    '''Always recompile the entire JS codebase by setting `force` to True.
-    This is because BrowserifyCompiler only takes the root file, and if
-    it hasn't changed, it won't recompile anything.'''
-
-    def compile_file(self, infile, outfile, outdated=False, force=False):
-        return super(BrowserifyCompiler, self).compile_file(
-            infile,
-            outfile,
-            outdated,
-            True)

--- a/huxley/www/static/js/huxley/components/AdvisorRosterView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorRosterView.js
@@ -1,8 +1,6 @@
 /**
  * Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
  * Use of this source code is governed by a BSD License (see LICENSE).
- *
- * @jsx React.DOM
  */
 
 'use strict';

--- a/huxley/www/templates/www.html
+++ b/huxley/www/templates/www.html
@@ -19,7 +19,7 @@
             ContactTypes = {{ contact_types|safe }};
             ProgramTypes = {{ program_types|safe }};
         </script>
-        {% javascript 'huxley' %}
+        <script type="text/javascript" src="/static/js/bundle.js"></script>
     {% endblock js %}
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "huxley/www/static/js/huxley.browserify.js",
   "license": "BSD",
   "dependencies": {
-    "browserify": "6.3.2",
     "classnames": "2.2.5",
     "es6-promise": "2.0.0",
     "flux": "^2.1.1",
@@ -43,9 +42,6 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
-    "babelify": "~6.3.0",
-    "detachkify": "0.0.6",
-    "envify": "~3.4.0",
     "jest-cli": "~0.4.0",
     "uglify-js": "~2.4.15",
     "webpack": "^1.13.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ coverage==3.7.1
 cssmin==0.2.0
 django-easy-pdf==0.1.0
 django-pipeline==1.6.8
-django-pipeline-browserify==0.4.0
 djangorestframework==3.3.1
 ecdsa==0.11
 futures==3.0.5


### PR DESCRIPTION
Ditches pipeline+browserify for JS. Removes the browserify dependencies, pipeline settings, and adjusts the deploy command in fabric to build the JS before running collectstatic.

Resolves #387.