### PR TITLE
Fixed internationalization bugs and updated payment text (#498)

### DIFF
--- a/huxley/api/serializers/school.py
+++ b/huxley/api/serializers/school.py
@@ -78,6 +78,7 @@ class SchoolSerializer(serializers.ModelSerializer):
         international = data.get('international')
         primary_phone = data.get('primary_phone')
         secondary_phone = data.get('secondary_phone')
+        school_zip = data.get('zip_code')
         beginner_delegates = data.get('beginner_delegates')
         intermediate_delegates = data.get('intermediate_delegates')
         advanced_delegates = data.get('advanced_delegates')
@@ -95,6 +96,10 @@ class SchoolSerializer(serializers.ModelSerializer):
             else:
                 validators.phone_domestic(phone)
 
+        def validate_zip_code(school_zip, international):
+            if not international:
+                validators.numeric(school_zip)
+
         if primary_phone:
             try:
                 validate_phone(primary_phone, international)
@@ -105,6 +110,12 @@ class SchoolSerializer(serializers.ModelSerializer):
                 validate_phone(secondary_phone, international)
             except serializers.ValidationError:
                 invalid_fields['secondary_phone'] = 'This is an invalid phone number.'
+
+        if school_zip:
+            try:
+                validate_zip_code(school_zip, international)
+            except serializers.ValidationError:
+                invalid_fields['zip_code'] = 'This field can only contain numbers and spaces.'
 
         if spanish_speaking_delegates > total_delegates:
             invalid_fields['spanish_speaking_delegates'] = 'Cannot exceed total number of delegates.'
@@ -153,13 +164,6 @@ class SchoolSerializer(serializers.ModelSerializer):
         school_city = value
 
         validators.name(school_city)
-
-        return value
-
-    def validate_zip_code(self, value):
-        school_zip = value
-
-        validators.numeric(school_zip)
 
         return value
 

--- a/huxley/api/templates/invoice.html
+++ b/huxley/api/templates/invoice.html
@@ -137,8 +137,7 @@
           <tr>
             <td colspan="2" class="info">
               Please email info@bmun.org if you have any questions. If you wish
-              to pay online via credit card, please email info@bmun.org. Note if
-              you pay online, there will be a 2.75% credit card processing fee.
+              to pay online via credit card, please email info@bmun.org.
             </td>
             <td colspan="2" class="info" style="text-align:right">
               info@bmun.org<br>

--- a/huxley/www/static/js/huxley/components/AdvisorProfileView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorProfileView.js
@@ -77,8 +77,10 @@ var AdvisorProfileView = React.createClass({
         </p>
         <p><strong>Remember to save!</strong></p>
         <p><strong>Important Note:</strong> Please mail all checks to <strong>
-        P.O. Box 4306 Berkeley, CA 94704-0306.</strong> If you have any other further
-        questions contact me at <a href="mailto:info@bmun.org">
+        P.O. Box 4306 Berkeley, CA 94704-0306</strong> or, if online paying via
+        credit card, please email <a href="mailto:info@bmun.org">
+        info@bmun.org</a> to access the online payment portal. If you have any
+        other further questions contact me at <a href="mailto:info@bmun.org">
         info@bmun.org</a> and I will respond to all requests efficiently.
         See you soon!</p>
         <p><strong>{conference.external}

--- a/huxley/www/static/js/huxley/components/RegistrationView.js
+++ b/huxley/www/static/js/huxley/components/RegistrationView.js
@@ -212,7 +212,7 @@ var RegistrationView = React.createClass({
             <TextInput
               placeholder="Country"
               value={this._getSchoolCountry()}
-              onChange={_handleChange.bind(this, 'school_international')}
+              onChange={_handleChange.bind(this, 'school_country')}
               disabled={!this.state.school_international}
             />
             {this.renderSchoolError('country')}


### PR DESCRIPTION
When selecting "International" on the registration form you couldn't input the country name.
International zip codes do sometimes contain characters other numbers so I adjusted the zip code validation to handle that.
Updated some of the text with new payment details.