### PR TITLE
Small language adjustment in AdvisorProfileView.

### DIFF
--- a/huxley/www/static/js/huxley/components/AdvisorProfileView.js
+++ b/huxley/www/static/js/huxley/components/AdvisorProfileView.js
@@ -76,12 +76,10 @@ var AdvisorProfileView = React.createClass({
           the Fees tab. You will receive an invoice in your email.
         </p>
         <p><strong>Remember to save!</strong></p>
-        <p><strong>Important Note:</strong> Please mail all checks to <strong>
-        P.O. Box 4306 Berkeley, CA 94704-0306</strong> or, if online paying via
-        credit card, please email <a href="mailto:info@bmun.org">
-        info@bmun.org</a> to access the online payment portal. If you have any
-        other further questions contact me at <a href="mailto:info@bmun.org">
-        info@bmun.org</a> and I will respond to all requests efficiently.
+        <p><strong>Important Note:</strong> Please mail all checks to
+        <strong>P.O. Box 4306 Berkeley, CA 94704-0306</strong>. If you'd like to pay online via
+        credit card, or if you have any further questions, please contact me at
+        <a href="mailto:info@bmun.org">info@bmun.org</a> and I will respond promptly.
         See you soon!</p>
         <p><strong>{conference.external}
         <br />


### PR DESCRIPTION
We didn't need two info@bmun.org email links within a few words of each other.