### PR TITLE
Use Node 6 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+node_js:
+    - "6"
 install: pip install -r requirements.txt
 before_script:
     - python manage.py migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
 python:
     - "2.7"
-node_js:
-    - "6"
-install: pip install -r requirements.txt
+install:
+    - pip install -r requirements.txt
+    - nvm install 6
+    - nvm use 6
+    - npm install
 before_script:
     - python manage.py migrate
-    - npm install
 script:
     - python manage.py test
     - npm test


### PR DESCRIPTION
This finally fixes Travis! Uses the latest version of Node in the build.