### PR TITLE
Introduce ServerAPI.

### DIFF
--- a/huxley/www/static/js/huxley/lib/ServerAPI.js
+++ b/huxley/www/static/js/huxley/lib/ServerAPI.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
+ * Use of this source code is governed by a BSD License (see LICENSE).
+ */
+
+var $ = require('jquery');
+
+/**
+ * The ServerAPI exists to centralize and abstract calls to the server. Any
+ * code interacting with the server should go through this interface.
+ */
+var ServerAPI = {
+  /**
+   * Get a list of all assignments for the given school ID.
+   */
+  getAssignments(schoolID) {
+    return _get(`/api/schools/${schoolID}/assignments`);
+  },
+
+  /**
+   * Get a list of all committees.
+   */
+  getCommittees() {
+    return _get('/api/committees');
+  },
+
+  /**
+   * Get a list of all countries.
+   */
+  getCountries() {
+    return _get('/api/countries');
+  },
+
+  /**
+   * Get a list of all delegates for the given school ID.
+   */
+  getDelegates(schoolID) {
+    return _get(`/api/schools/${schoolID}/delegates`);
+  },
+};
+
+function _get(uri) {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      type: 'GET',
+      url: uri,
+      dataType: 'json',
+      success: (data, textStatus, jqXHR) => {
+        resolve(jqXHR.responseJSON);
+      },
+    });
+  });
+}
+
+module.exports = ServerAPI;

--- a/huxley/www/static/js/huxley/stores/AssignmentStore.js
+++ b/huxley/www/static/js/huxley/stores/AssignmentStore.js
@@ -7,30 +7,21 @@
 
 var $ = require('jquery');
 var Dispatcher = require('dispatcher/Dispatcher');
+var ServerAPI = require('lib/ServerAPI');
 var {Store} = require('flux/utils');
 
 
-var _assignmentPromise = null;
+var _assignmentPromises = {};
 
 class AssignmentStore extends Store {
   getAssignments(schoolID, callback) {
-    if (!_assignmentPromise) {
-      _assignmentPromise = new Promise(function(resolve, reject) {
-        $.ajax({
-          type: 'GET',
-          url: '/api/schools/'+schoolID+'/assignments',
-          dataType: 'json',
-          success: function(data, textStatus, jqXHR) {
-            resolve(jqXHR.responseJSON);
-          },
-        });
-      });
+    if (!_assignmentPromises[schoolID]) {
+      _assignmentPromises[schoolID] = ServerAPI.getAssignments(schoolID);
     }
-
     if (callback) {
-      _assignmentPromise.then(callback);
+      _assignmentPromises[schoolID].then(callback);
     }
-    return _assignmentPromise;
+    return _assignmentPromises[schoolID];
   }
 
   __onDispatch(action) {

--- a/huxley/www/static/js/huxley/stores/CommitteeStore.js
+++ b/huxley/www/static/js/huxley/stores/CommitteeStore.js
@@ -7,6 +7,7 @@
 
 var $ = require('jquery');
 var Dispatcher = require('dispatcher/Dispatcher');
+var ServerAPI = require('lib/ServerAPI');
 var {Store} = require('flux/utils');
 
 
@@ -15,18 +16,8 @@ var _committeePromise = null;
 class CommitteeStore extends Store {
   getCommittees(callback) {
     if (!_committeePromise) {
-      _committeePromise = new Promise(function(resolve, reject) {
-        $.ajax({
-          type: 'GET',
-          url: '/api/committees',
-          dataType: 'json',
-          success: function(data, textStatus, jqXHR) {
-            resolve(jqXHR.responseJSON);
-          },
-        });
-      });
+      _committeePromise = ServerAPI.getCommittees();
     }
-
     if (callback) {
       _committeePromise.then(callback);
     }

--- a/huxley/www/static/js/huxley/stores/CountryStore.js
+++ b/huxley/www/static/js/huxley/stores/CountryStore.js
@@ -7,6 +7,7 @@
 
 var $ = require('jquery');
 var Dispatcher = require('dispatcher/Dispatcher');
+var ServerAPI = require('lib/ServerAPI');
 var {Store} = require('flux/utils');
 
 
@@ -15,18 +16,8 @@ var _countryPromise = null;
 class CountryStore extends Store {
   getCountries(callback) {
     if (!_countryPromise) {
-      _countryPromise = new Promise(function(resolve, reject) {
-        $.ajax({
-          type: 'GET',
-          url: '/api/countries',
-          dataType: 'json',
-          success: function(data, textStatus, jqXHR) {
-            resolve(jqXHR.responseJSON);
-          },
-        });
-      });
+      _countryPromise = ServerAPI.getCountries();
     }
-
     if (callback) {
       _countryPromise.then(callback);
     }

--- a/huxley/www/static/js/huxley/stores/DelegateStore.js
+++ b/huxley/www/static/js/huxley/stores/DelegateStore.js
@@ -7,6 +7,7 @@
 
 var $ = require('jquery');
 var Dispatcher = require('dispatcher/Dispatcher');
+var ServerAPI = require('lib/ServerAPI');
 var {Store} = require('flux/utils');
 
 
@@ -15,18 +16,8 @@ var _delegatePromises = {};
 class DelegateStore extends Store {
   getDelegates(schoolID, callback) {
     if (!_delegatePromises[schoolID]) {
-      _delegatePromises[schoolID] = new Promise(function(resolve, reject) {
-        $.ajax({
-          type: 'GET',
-          url: '/api/schools/'+schoolID+'/delegates',
-          dataType: 'json',
-          success: function(data, textStatus, jqXHR) {
-            resolve(jqXHR.responseJSON);
-          },
-        });
-      });
+      _delegatePromises[schoolID] = ServerAPI.getDelegates(schoolID);
     }
-
     if (callback) {
       _delegatePromises[schoolID].then(callback);
     }

--- a/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
@@ -8,22 +8,19 @@
 jest.dontMock('stores/AssignmentStore');
 
 describe('AssignmentStore', () => {
-  var $;
   var AssignmentStore;
   var Dispatcher;
+  var ServerAPI;
 
   var mockAssignments;
 
   beforeEach(() => {
-    $ = require('jquery');
     AssignmentStore = require('stores/AssignmentStore');
     Dispatcher = require('dispatcher/Dispatcher');
+    ServerAPI = require('lib/ServerAPI');
 
     mockAssignments = [{id: 1, school: 1}, {id: 2, school: 1}];
-
-    $.ajax.mockImplementation((options) => {
-      options.success(null, null, {responseJSON: mockAssignments});
-    });
+    ServerAPI.getAssignments.mockReturnValue(Promise.resolve(mockAssignments));
   });
 
   it('subscribes to the dispatcher', () => {
@@ -33,16 +30,11 @@ describe('AssignmentStore', () => {
   it('requests the assignments on first call and caches locally', () => {
     return Promise.all([
       AssignmentStore.getAssignments(1).then((assignments) => {
-        expect($.ajax).toBeCalledWith({
-          type: 'GET',
-          url: '/api/schools/1/assignments',
-          dataType: 'json',
-          success: jasmine.any(Function),
-        });
+        expect(ServerAPI.getAssignments).toBeCalledWith(1);
         expect(assignments).toEqual(mockAssignments);
       }),
       AssignmentStore.getAssignments(1).then((assignments) => {
-        expect($.ajax.mock.calls.length).toBe(1);
+        expect(ServerAPI.getAssignments).toBeCalledWith(1);
         expect(assignments).toBe(mockAssignments);
       }),
     ]);

--- a/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/AssignmentStore-test.js
@@ -34,7 +34,7 @@ describe('AssignmentStore', () => {
         expect(assignments).toEqual(mockAssignments);
       }),
       AssignmentStore.getAssignments(1).then((assignments) => {
-        expect(ServerAPI.getAssignments).toBeCalledWith(1);
+        expect(ServerAPI.getAssignments.mock.calls.length).toBe(1);
         expect(assignments).toBe(mockAssignments);
       }),
     ]);

--- a/huxley/www/static/js/huxley/stores/__tests__/CommitteeStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/CommitteeStore-test.js
@@ -8,26 +8,24 @@
 jest.dontMock('stores/CommitteeStore');
 
 describe('CommitteeStore', () => {
-  var $;
   var CommitteeStore;
   var Dispatcher;
+  var ServerAPI;
 
   var disc;
   var icj;
   var mockCommittees;
 
   beforeEach(() => {
-    $ = require('jquery');
     CommitteeStore = require('stores/CommitteeStore');
     Dispatcher = require('dispatcher/Dispatcher');
+    ServerAPI = require('lib/ServerAPI');
 
     disc = {id: 1, name: 'DISC', special: false};
     icj = {id: 2, name: 'ICJ', special: true};
     mockCommittees = [disc, icj];
 
-    $.ajax.mockImplementation((options) => {
-      options.success(null, null, {responseJSON: mockCommittees});
-    });
+    ServerAPI.getCommittees.mockReturnValue(Promise.resolve(mockCommittees));
   });
 
   it('subscribes to the dispatcher', () => {
@@ -37,16 +35,9 @@ describe('CommitteeStore', () => {
   it('requests the committees on first call and caches locally', () => {
     return Promise.all([
       CommitteeStore.getCommittees().then((committees) => {
-        expect($.ajax).toBeCalledWith({
-          type: 'GET',
-          url: '/api/committees',
-          dataType: 'json',
-          success: jasmine.any(Function),
-        });
         expect(committees).toEqual(mockCommittees);
       }),
       CommitteeStore.getCommittees().then((committees) => {
-        expect($.ajax.mock.calls.length).toBe(1);
         expect(committees).toEqual(mockCommittees);
       }),
     ]);

--- a/huxley/www/static/js/huxley/stores/__tests__/CountryStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/CountryStore-test.js
@@ -8,21 +8,19 @@
 jest.dontMock('stores/CountryStore');
 
 describe('CountryStore', () => {
-  var $;
   var CountryStore;
   var Dispatcher;
+  var ServerAPI;
 
   var mockCountries;
 
   beforeEach(() => {
-    $ = require('jquery');
     CountryStore = require('stores/CountryStore');
     Dispatcher = require('dispatcher/Dispatcher');
+    ServerAPI = require('lib/ServerAPI');
 
     mockCountries = [{id: 1, name: 'USA'}, {id: 2, name: 'China'}];
-    $.ajax.mockImplementation((options) => {
-      options.success(null, null, {responseJSON: mockCountries});
-    });
+    ServerAPI.getCountries.mockReturnValue(Promise.resolve(mockCountries));
   });
 
   it('subscribes to the dispatcher', () => {
@@ -32,16 +30,9 @@ describe('CountryStore', () => {
   it('requests the countries on first call and caches locally', () => {
     return Promise.all([
       CountryStore.getCountries().then((countries) => {
-        expect($.ajax).toBeCalledWith({
-          type: 'GET',
-          url: '/api/countries',
-          dataType: 'json',
-          success: jasmine.any(Function),
-        });
         expect(countries).toEqual(mockCountries);
       }),
       CountryStore.getCountries().then((countries) => {
-        expect($.ajax.mock.calls.length).toBe(1);
         expect(countries).toEqual(mockCountries);
       }),
     ]);

--- a/huxley/www/static/js/huxley/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/DelegateStore-test.js
@@ -35,7 +35,7 @@ describe('DelegateStore', () => {
         expect(delegates).toEqual(mockDelegates);
       }),
       DelegateStore.getDelegates(mockSchoolId, (delegates) => {
-        expect(ServerAPI.getDelegates).toBeCalledWith(mockSchoolId);
+        expect(ServerAPI.getDelegates.mock.calls.length).toBe(1);
         expect(delegates).toEqual(mockDelegates);
       }),
     ]);

--- a/huxley/www/static/js/huxley/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/static/js/huxley/stores/__tests__/DelegateStore-test.js
@@ -8,22 +8,20 @@
 jest.dontMock('stores/DelegateStore');
 
 describe('DelegateStore', () => {
-  var $;
   var DelegateStore;
   var Dispatcher;
+  var ServerAPI;
 
   var mockDelegates, mockSchoolId;
 
   beforeEach(() => {
-    $ = require('jquery');
     DelegateStore = require('stores/DelegateStore');
     Dispatcher = require('dispatcher/Dispatcher');
+    ServerAPI = require('lib/ServerAPI');
 
     mockDelegates = [{id: 1, name: 'Jake'}, {id: 2, name: 'Nate'}];
     mockSchoolId = 0;
-    $.ajax.mockImplementation((options) => {
-      options.success(null, null, {responseJSON: mockDelegates});
-    });
+    ServerAPI.getDelegates.mockReturnValue(Promise.resolve(mockDelegates));
   });
 
   it('subscribes to the dispatcher', () => {
@@ -33,16 +31,11 @@ describe('DelegateStore', () => {
   it('requests the delegates on first call and caches locally', () => {
     return Promise.all([
       DelegateStore.getDelegates(mockSchoolId, (delegates) => {
-        expect($.ajax).toBeCalledWith({
-          type: 'GET',
-          url: '/api/schools/' + mockSchoolId + '/delegates',
-          dataType: 'json',
-          success: jasmine.any(Function),
-        });
+        expect(ServerAPI.getDelegates).toBeCalledWith(mockSchoolId);
         expect(delegates).toEqual(mockDelegates);
       }),
       DelegateStore.getDelegates(mockSchoolId, (delegates) => {
-        expect($.ajax.mock.calls.length).toBe(1);
+        expect(ServerAPI.getDelegates).toBeCalledWith(mockSchoolId);
         expect(delegates).toEqual(mockDelegates);
       }),
     ]);


### PR DESCRIPTION
This adds ServerAPI, which will centralize AJAX calls to the server. We start with simple GET calls from the Stores. Followups can convert at their leisure. (#510)