### PR TITLE
Add chinese_speaking_delegates advisor.json fixture.

### DIFF
--- a/huxley/core/fixtures/advisor.json
+++ b/huxley/core/fixtures/advisor.json
@@ -42,6 +42,7 @@
       "intermediate_delegates": 5,
       "advanced_delegates": 5,
       "spanish_speaking_delegates": 5,
+      "chinese_speaking_delegates": 5,
       "fees_paid": 0.0
     }
   }


### PR DESCRIPTION
The schema was changed but we forgot to update the fixture.