### PR TITLE
Add pylint to workflow

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -42,7 +42,7 @@ def update():
 
 @task
 def lint():
-    '''Format and commit python files committed on the current feature branch'''
+    '''Run linter evaluation of files committed on current feature branch'''
     diff_list = git.diff_name_only()
     py_diff_list = [pyfile for pyfile in diff_list if pyfile.endswith('.py')]
 
@@ -77,6 +77,11 @@ def format():
 @task
 def submit(remote='origin', skip_tests=False):
     '''Push the current feature branch and create/update pull request.'''
+    if confirm('View linter evluation? (Will not change code)'):
+        lint()
+        if not confirm('Continue submit?'):
+            return
+
     format()
     if not skip_tests:
         with settings(warn_only=True):

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -77,7 +77,7 @@ def format():
 @task
 def submit(remote='origin', skip_tests=False):
     '''Push the current feature branch and create/update pull request.'''
-    if confirm('View linter evluation? (Will not change code)'):
+    if confirm('View linter evaluation? (Will not change code)'):
         lint()
         if not confirm('Continue submit?'):
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ six==1.7.3
 wsgiref==0.1.2
 xhtml2pdf==0.0.6
 yapf==0.11.0
-astroid=1.4.8
-pylint=1.6.4
+astroid==1.4.8
+pylint==1.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ six==1.7.3
 wsgiref==0.1.2
 xhtml2pdf==0.0.6
 yapf==0.11.0
+astroid=1.4.8
+pylint=1.6.4


### PR DESCRIPTION
Sorry about the initial long title, I forgot where I was entering the stuff. 

This adds Pylint to the workflow. Upon submit users will have the option to view a brief Pylint evaluation of the python files that were changed. They can then choose to continue with the submit based off the evaluation. This only prints an evluation, it does not alter the code in anyway (which is why I seperated it from the format command). This address issue #294.