### PR TITLE
Added committee preferences column when downloading assignment preferences from admin portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ htmlcov/
 
 node_modules/
 
-huxley/wwww/static/js/
+huxley/www/static/js/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ fabfile/deploy.py
 htmlcov/
 
 node_modules/
+
+huxley/wwww/static/js/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ htmlcov/
 
 node_modules/
 
-huxley/www/static/js/
+huxley/www/static/js/bundle.js

--- a/huxley/core/admin/schools.py
+++ b/huxley/core/admin/schools.py
@@ -117,12 +117,14 @@ class SchoolAdmin(admin.ModelAdmin):
                 "Country 8",
                 "Country 9",
                 "Country 10",
+                "Committee Preferences"
                 "Registration Comments"
                 ])
 
         for school in School.objects.all().order_by('name'):
             countryprefs = [c for c in school.countrypreferences.all().order_by('countrypreference')]
             countryprefs += [''] * (10 - len(countryprefs))
+            committeeprefs = [', '.join([c.name for c in school.committeepreferences.all()])]
 
             writer.writerow([unicode(field).encode('utf8') for field in [
                 school.name,
@@ -133,6 +135,7 @@ class SchoolAdmin(admin.ModelAdmin):
                 school.spanish_speaking_delegates,
                 school.chinese_speaking_delegates]] +
                 countryprefs +
+                committeeprefs +
                 [unicode(school.registration_comments).encode('utf8')
             ])
 

--- a/huxley/core/admin/schools.py
+++ b/huxley/core/admin/schools.py
@@ -107,7 +107,7 @@ class SchoolAdmin(admin.ModelAdmin):
             "Advanced", "Spanish Speakers", "Chinese Speakers", "Country 1",
             "Country 2", "Country 3", "Country 4", "Country 5", "Country 6",
             "Country 7", "Country 8", "Country 9", "Country 10",
-            "Committee Preferences"
+            "Committee Preferences",
             "Registration Comments"
         ])
 

--- a/huxley/core/admin/schools.py
+++ b/huxley/core/admin/schools.py
@@ -9,9 +9,10 @@ from django.http import HttpResponse
 
 from huxley.core.models import School
 
+
 class SchoolAdmin(admin.ModelAdmin):
 
-    readonly_fields = ('balance',)
+    readonly_fields = ('balance', )
 
     def calc_balance(self, obj):
         return obj.balance()
@@ -57,38 +58,39 @@ class SchoolAdmin(admin.ModelAdmin):
         ])
 
         for school in School.objects.all().order_by('name'):
-            writer.writerow([unicode(field).encode('utf8') for field in [
-                school.id,
-                school.name,
-                school.address,
-                school.city,
-                school.state,
-                school.zip_code,
-                school.country,
-                school.primary_name,
-                school.primary_gender,
-                school.primary_email,
-                school.primary_phone,
-                school.primary_type,
-                school.secondary_name,
-                school.secondary_gender,
-                school.secondary_email,
-                school.secondary_phone,
-                school.secondary_type,
-                school.program_type,
-                school.times_attended,
-                school.international,
-                school.waitlist,
-                school.beginner_delegates,
-                school.intermediate_delegates,
-                school.advanced_delegates,
-                school.spanish_speaking_delegates,
-                school.chinese_speaking_delegates,
-                school.registration_comments,
-                school.fees_owed,
-                school.fees_paid,
-                school.modified_at.isoformat(),
-            ]])
+            writer.writerow([unicode(field).encode('utf8')
+                             for field in [
+                                 school.id,
+                                 school.name,
+                                 school.address,
+                                 school.city,
+                                 school.state,
+                                 school.zip_code,
+                                 school.country,
+                                 school.primary_name,
+                                 school.primary_gender,
+                                 school.primary_email,
+                                 school.primary_phone,
+                                 school.primary_type,
+                                 school.secondary_name,
+                                 school.secondary_gender,
+                                 school.secondary_email,
+                                 school.secondary_phone,
+                                 school.secondary_type,
+                                 school.program_type,
+                                 school.times_attended,
+                                 school.international,
+                                 school.waitlist,
+                                 school.beginner_delegates,
+                                 school.intermediate_delegates,
+                                 school.advanced_delegates,
+                                 school.spanish_speaking_delegates,
+                                 school.chinese_speaking_delegates,
+                                 school.registration_comments,
+                                 school.fees_owed,
+                                 school.fees_paid,
+                                 school.modified_at.isoformat(),
+                             ]])
 
         return schools
 
@@ -96,63 +98,49 @@ class SchoolAdmin(admin.ModelAdmin):
         ''' Returns a CSV file containing the current set of
             Schools registered with all of its fields. '''
         schools = HttpResponse(content_type='text/csv')
-        schools['Content-Disposition'] = 'attachment; filename="preferences.csv"'
+        schools[
+            'Content-Disposition'] = 'attachment; filename="preferences.csv"'
         writer = csv.writer(schools)
 
         writer.writerow([
-                "Name",
-                "Assignments Requested",
-                "Beginners",
-                "Intermediates",
-                "Advanced",
-                "Spanish Speakers",
-                "Chinese Speakers",
-                "Country 1",
-                "Country 2",
-                "Country 3",
-                "Country 4",
-                "Country 5",
-                "Country 6",
-                "Country 7",
-                "Country 8",
-                "Country 9",
-                "Country 10",
-                "Committee Preferences"
-                "Registration Comments"
-                ])
+            "Name", "Assignments Requested", "Beginners", "Intermediates",
+            "Advanced", "Spanish Speakers", "Chinese Speakers", "Country 1",
+            "Country 2", "Country 3", "Country 4", "Country 5", "Country 6",
+            "Country 7", "Country 8", "Country 9", "Country 10",
+            "Committee Preferences"
+            "Registration Comments"
+        ])
 
         for school in School.objects.all().order_by('name'):
-            countryprefs = [c for c in school.countrypreferences.all().order_by('countrypreference')]
+            countryprefs = [c
+                            for c in school.countrypreferences.all().order_by(
+                                'countrypreference')]
             countryprefs += [''] * (10 - len(countryprefs))
-            committeeprefs = [', '.join([c.name for c in school.committeepreferences.all()])]
+            committeeprefs = [', '.join(
+                [c.name for c in school.committeepreferences.all()])]
 
-            writer.writerow([unicode(field).encode('utf8') for field in [
-                school.name,
-                school.beginner_delegates + school.intermediate_delegates + school.advanced_delegates,
-                school.beginner_delegates,
-                school.intermediate_delegates,
-                school.advanced_delegates,
-                school.spanish_speaking_delegates,
-                school.chinese_speaking_delegates]] +
-                countryprefs +
-                committeeprefs +
-                [unicode(school.registration_comments).encode('utf8')
-            ])
+            writer.writerow(
+                [unicode(field).encode('utf8')
+                 for field in [
+                     school.name, school.beginner_delegates +
+                     school.intermediate_delegates + school.advanced_delegates,
+                     school.beginner_delegates, school.intermediate_delegates,
+                     school.advanced_delegates,
+                     school.spanish_speaking_delegates,
+                     school.chinese_speaking_delegates
+                 ]] + countryprefs + committeeprefs + [unicode(
+                     school.registration_comments).encode('utf8')])
 
         return schools
 
     def get_urls(self):
         urls = super(SchoolAdmin, self).get_urls()
-        urls += patterns('',
-            url(
-                r'info',
+        urls += patterns(
+            '',
+            url(r'info',
                 self.admin_site.admin_view(self.info),
-                name='core_school_info',
-            ),
-            url(
-                r'preferences',
+                name='core_school_info', ),
+            url(r'preferences',
                 self.admin_site.admin_view(self.preferences),
-                name='core_school_preferences'
-            )
-        )
+                name='core_school_preferences'))
         return urls

--- a/huxley/core/admin/schools.py
+++ b/huxley/core/admin/schools.py
@@ -107,8 +107,7 @@ class SchoolAdmin(admin.ModelAdmin):
             "Advanced", "Spanish Speakers", "Chinese Speakers", "Country 1",
             "Country 2", "Country 3", "Country 4", "Country 5", "Country 6",
             "Country 7", "Country 8", "Country 9", "Country 10",
-            "Committee Preferences",
-            "Registration Comments"
+            "Committee Preferences", "Registration Comments"
         ])
 
         for school in School.objects.all().order_by('name'):

--- a/huxley/core/tests/admin/test_school.py
+++ b/huxley/core/tests/admin/test_school.py
@@ -109,41 +109,32 @@ class SchoolAdminTest(TestCase):
         self.assertTrue(response)
 
         header = [
-            "Name",
-            "Assignments Requested",
-            "Beginners",
-            "Intermediates",
-            "Advanced",
-            "Spanish Speakers",
-            "Chinese Speakers",
-            "Country 1",
-            "Country 2",
-            "Country 3",
-            "Country 4",
-            "Country 5",
-            "Country 6",
-            "Country 7",
-            "Country 8",
-            "Country 9",
-            "Country 10",
-            "Committee Preferences",
-            "Registration Comments"
-            ]
+            "Name", "Assignments Requested", "Beginners", "Intermediates",
+            "Advanced", "Spanish Speakers", "Chinese Speakers", "Country 1",
+            "Country 2", "Country 3", "Country 4", "Country 5", "Country 6",
+            "Country 7", "Country 8", "Country 9", "Country 10",
+            "Committee Preferences", "Registration Comments"
+        ]
 
         fields_csv = ",".join(map(str, header)) + "\r\n"
 
-        countryprefs = [c for c in school.countrypreferences.all().order_by('countrypreference')]
+        countryprefs = [c
+                        for c in school.countrypreferences.all().order_by(
+                            'countrypreference')]
         countryprefs += [''] * (10 - len(countryprefs))
-        committeeprefs = [', '.join([c.name for c in school.committeepreferences.all()])]
+        committeeprefs = [', '.join(
+            [c.name for c in school.committeepreferences.all()])]
 
         fields = [
-                school.name,
-                school.beginner_delegates + school.intermediate_delegates + school.advanced_delegates,
-                school.beginner_delegates,
-                school.intermediate_delegates,
-                school.advanced_delegates,
-                school.spanish_speaking_delegates,
-                school.chinese_speaking_delegates,]
+            school.name,
+            school.beginner_delegates + school.intermediate_delegates +
+            school.advanced_delegates,
+            school.beginner_delegates,
+            school.intermediate_delegates,
+            school.advanced_delegates,
+            school.spanish_speaking_delegates,
+            school.chinese_speaking_delegates,
+        ]
         fields.extend(countryprefs)
         fields.extend(committeeprefs)
         fields.append(school.registration_comments)

--- a/huxley/core/tests/admin/test_school.py
+++ b/huxley/core/tests/admin/test_school.py
@@ -126,6 +126,7 @@ class SchoolAdminTest(TestCase):
             "Country 8",
             "Country 9",
             "Country 10",
+            "Committee Preferences",
             "Registration Comments"
             ]
 
@@ -133,6 +134,7 @@ class SchoolAdminTest(TestCase):
 
         countryprefs = [c for c in school.countrypreferences.all().order_by('countrypreference')]
         countryprefs += [''] * (10 - len(countryprefs))
+        committeeprefs = [', '.join([c.name for c in school.committeepreferences.all()])]
 
         fields = [
                 school.name,
@@ -143,6 +145,7 @@ class SchoolAdminTest(TestCase):
                 school.spanish_speaking_delegates,
                 school.chinese_speaking_delegates,]
         fields.extend(countryprefs)
+        fields.extend(committeeprefs)
         fields.append(school.registration_comments)
 
         fields_csv += ",".join(map(str, fields))


### PR DESCRIPTION
External expressed a need to include the committee preferences of a school along with a school's country preferences when downloading those preferences from the admin panel. This diff

1. Adds a column that lists a school's committee preferences if any
2. Updates tests to reflect that
3. updates the .gitignore file to ignore `huxley/www/static/js/`