### PR TITLE
Waitlist schools from the admin panel

### DIFF
--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -176,7 +176,8 @@ class School(models.Model):
         '''If the school is about to be created (i.e. has no ID) and
         registration is closed, add it to the waitlist.'''
         school = kwargs['instance']
-        if not school.id and settings.CONFERENCE_WAITLIST_OPEN:
+        conference = Conference.get_current()
+        if not school.id and conference.waitlist_reg:
             school.waitlist = True
 
     @property
@@ -233,7 +234,7 @@ class School(models.Model):
                     'BMUN %d Registration Confirmation' % conference.session,
                     'Congratulations, you have officially been registered for BMUN %d. '
                     'To access your account, please log in at huxley.bmun.org.\n\n'
-                    'In order to confirm your spot on our registration list, ' 
+                    'In order to confirm your spot on our registration list, '
                     'you must pay the non-refundable school fee of $%d. '
                     'In 24-48 hours, you will receive an invoice from QuickBooks, '
                     'our accounting system, for your school fee. '
@@ -250,7 +251,7 @@ class School(models.Model):
                     'at http://bmun.org/alumni-scholarship/. This year we will be '
                     'awarding up to $13,000 to those that apply.\n\n'
                     'If you have any questions, please contact info@bmun.org.\n\n'
-                    'Thank you for registering for BMUN, and we look forward to ' 
+                    'Thank you for registering for BMUN, and we look forward to '
                     'seeing you at the oldest high school conference in the world '
                     'on March 3-5, 2017.' %
                     (conference.session, int(registration_fee),

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -122,18 +122,18 @@ class SchoolTest(TestCase):
         )
 
     def test_update_waitlist(self):
-        '''New schools should be waitlisted based on the conference settings.'''
-        self.assertTrue(hasattr(settings, 'CONFERENCE_WAITLIST_OPEN'))
+        '''New schools should be waitlisted based on the conference waitlist field.'''
+        s1 = TestSchools.new_school()
+        self.assertFalse(s1.waitlist)
 
-        with self.settings(CONFERENCE_WAITLIST_OPEN=False):
-            s1 = TestSchools.new_school()
-            self.assertFalse(s1.waitlist)
+        conference = Conference.get_current()
+        conference.waitlist_reg = True
+        conference.save()
 
-        with self.settings(CONFERENCE_WAITLIST_OPEN=True):
-            s1.save()
-            self.assertFalse(s1.waitlist)
-            s2 = TestSchools.new_school()
-            self.assertTrue(s2.waitlist)
+        s1.save()
+        self.assertFalse(s1.waitlist)
+        s2 = TestSchools.new_school()
+        self.assertTrue(s2.waitlist)
 
 
 class AssignmentTest(TestCase):

--- a/huxley/settings/conference.py
+++ b/huxley/settings/conference.py
@@ -1,6 +1,4 @@
 # Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
-CONFERENCE_WAITLIST_OPEN = False
-
 SESSION = 65

--- a/huxley/www/js/components/RegistrationWaitlistView.js
+++ b/huxley/www/js/components/RegistrationWaitlistView.js
@@ -7,20 +7,26 @@
 
 var React = require('react');
 
+var ConferenceContext = require('components/ConferenceContext');
 var NavLink = require('components/NavLink');
 var OuterView = require('components/OuterView');
 
 var RegistrationWaitlistView = React.createClass({
+
+  contextTypes: {
+    conference: React.PropTypes.shape(ConferenceContext)
+  },
+
   render: function() {
     return (
       <OuterView>
         <div class="letter">
           <p>
-            Thank you for your interest in participating in the sixty-third
-            session of Berkeley Model United Nations! You are currently on our
+            Thank you for your interest in participating in
+            BMUN {conference.session}! You are currently on our
             wait list and will be updated on your team's status as spots become
             available again. We thank you for your patience in advance and hope
-            to see you at Berkeley next February!
+            to see you at Berkeley next March!
           </p>
         </div>
         <hr />


### PR DESCRIPTION
Waitlisting schools based off the `waitlist_reg` field on the conference model. This allows us to turn the waitlist on from the admin panel.

Also deprecated the waitlist setting from `conference.py`, and updated tests accordingly