### PR TITLE
removes delegate assignment on change of assignment's school field

### DIFF
--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
+# Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
 import json
@@ -306,7 +306,7 @@ class Assignment(models.Model):
             deletions.append(assignment_data['id'])
 
         for committee, country, school, rejected in new_assignments:
-            key = (committee, country)
+            key = (committee.id, country.id)
             if key in assigned:
                 # Make sure that the same committee/country pair is not being
                 # given to more than one school in the upload
@@ -361,6 +361,20 @@ class Assignment(models.Model):
 
         return failed_assignments
 
+    @classmethod
+    def update_assignment(cls, **kwargs):
+        assignment = kwargs['instance']
+        # Check that this assignment already exists
+        if assignment.id:
+            old_assignment = cls.objects.get(id=assignment.id)
+            # Check if school changed
+            if not assignment.school.id == old_assignment.school.id:
+                assignment.rejected = False
+                delegates = Delegate.objects.filter(assignment_id=old_assignment.id)
+                for delegate in delegates:
+                    delegate.assignment = None
+                    delegate.save()
+
     def __unicode__(self):
         return self.committee.name + " : " + self.country.name + " : " + (
             self.school.name if self.school else "Unassigned")
@@ -369,6 +383,7 @@ class Assignment(models.Model):
         db_table = u'assignment'
         unique_together = ('committee', 'country')
 
+pre_save.connect(Assignment.update_assignment, sender=Assignment)
 
 class CountryPreference(models.Model):
     school = models.ForeignKey(School)

--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -371,7 +371,7 @@ class Assignment(models.Model):
             return
 
         old_assignment = cls.objects.get(id=assignment.id)
-        if not assignment.school.id == old_assignment.school.id:
+        if assignment.school_id != old_assignment.school_id:
             assignment.rejected = False
             Delegate.objects.filter(assignment_id=old_assignment.id).update(assignment=None)
 

--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -363,17 +363,17 @@ class Assignment(models.Model):
 
     @classmethod
     def update_assignment(cls, **kwargs):
+        '''Ensures that when an assignment's school field changes,
+           any delegates assigned to that assignment are no longer
+           assigned to it and that its rejected field is false.'''
         assignment = kwargs['instance']
-        # Check that this assignment already exists
-        if assignment.id:
-            old_assignment = cls.objects.get(id=assignment.id)
-            # Check if school changed
-            if not assignment.school.id == old_assignment.school.id:
-                assignment.rejected = False
-                delegates = Delegate.objects.filter(assignment_id=old_assignment.id)
-                for delegate in delegates:
-                    delegate.assignment = None
-                    delegate.save()
+        if not assignment.id:
+            return
+
+        old_assignment = cls.objects.get(id=assignment.id)
+        if not assignment.school.id == old_assignment.school.id:
+            assignment.rejected = False
+            Delegate.objects.filter(assignment_id=old_assignment.id).update(assignment=None)
 
     def __unicode__(self):
         return self.committee.name + " : " + self.country.name + " : " + (

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -192,14 +192,12 @@ class AssignmentTest(TestCase):
         a = TestAssignments.new_assignment(school=s1, rejected=True)
         d1 = TestDelegates.new_delegate(school=s1, assignment=a)
         d2 = TestDelegates.new_delegate(school=s1, assignment=a)
+        self.assertEquals(a.delegates.count(), 2)
 
         a.school = s2
         a.save()
 
-        delegates = Delegate.objects.all()
-        for delegate in delegates:
-            self.assertTrue(delegate.id in [d1.id, d2.id])
-            self.assertEquals(delegate.assignment, None)
+        self.assertEquals(a.delegates.count(), 0)
         self.assertEquals(a.rejected, False)
 
 class CountryPreferenceTest(TestCase):

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -193,6 +193,7 @@ class AssignmentTest(TestCase):
         d1 = TestDelegates.new_delegate(school=s1, assignment=a)
         d2 = TestDelegates.new_delegate(school=s1, assignment=a)
         self.assertEquals(a.delegates.count(), 2)
+        self.assertTrue(a.rejected)
 
         a.school = s2
         a.save()

--- a/huxley/utils/test.py
+++ b/huxley/utils/test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
+# Copyright (c) 2011-2016 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
 import csv
@@ -111,14 +111,14 @@ class TestDelegates():
         a = kwargs.pop('assignment', None) or TestAssignments.new_assignment()
         s = kwargs.pop('school', None) or a.school
 
-        c = Delegate(
+        d = Delegate(
                 assignment=a,
                 school=s,
                 name=kwargs.pop('name', 'Nate Parke'),
                 email=kwargs.pop('email', 'nate@earthlink.gov'),
                 summary=kwargs.pop('summary', 'He did well!'),)
-        c.save()
-        return c
+        d.save()
+        return d
 
 class TestAssignments():
     @staticmethod


### PR DESCRIPTION
In the case where external changes the school field of an assignment, any delegate previously assigned to that assignment would remain assigned to it. Due to whatever unpredictable behavior that may come from that, this diff ensures that no delegate is assigned to an assignment when that assignment's school field is changed. It also sets that assignment's rejected field to `False`.

Additionally, I noticed a small bug in the `update_assignments` method of the Assignment model, and updated the tests to reflect that.