### PR TITLE
doesn't delete delegates by cascade when an assignment is deleted.

### DIFF
--- a/huxley/core/migrations/0017_auto_20161223_1155.py
+++ b/huxley/core/migrations/0017_auto_20161223_1155.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0016_auto_20160724_2344'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='delegate',
+            name='assignment',
+            field=models.ForeignKey(related_name='delegates', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='core.Assignment', null=True),
+        ),
+    ]

--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -403,7 +403,7 @@ class CountryPreference(models.Model):
 class Delegate(models.Model):
     school = models.ForeignKey(School, related_name='delegates', null=True)
     assignment = models.ForeignKey(
-        Assignment, related_name='delegates', blank=True, null=True)
+        Assignment, related_name='delegates', blank=True, null=True, on_delete=models.SET_NULL)
     name = models.CharField(max_length=64)
     email = models.EmailField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -181,7 +181,7 @@ class AssignmentTest(TestCase):
         delegates = Delegate.objects.all()
         updates = [(cm.id, ct.id, s.id, rej) for cm, ct, s, rej in updates]
         self.assertEquals(set(updates), set(new_assignments))
-        self.assertEquals(len(delegates), 0)
+        self.assertEquals(len(delegates), 2)
 
     def test_update_assignment(self):
         '''Tests that when an assignment changes schools, its rejected


### PR DESCRIPTION
This is to prevent the scenario where if a school's assignments are deleted, then none of its delegates that were assigned to those assignments would be deleted as well.