### PR TITLE
Merge SchoolAssignments into AssignmentList (#547)

### DIFF
--- a/huxley/api/permissions.py
+++ b/huxley/api/permissions.py
@@ -63,6 +63,7 @@ class IsSchoolAssignmentAdvisorOrSuperuser(permissions.BasePermission):
         return (user.is_authenticated() and user.is_advisor() and
                 user.school.id == assignment.school.id)
 
+
 class IsSchoolDelegateAdvisorOrSuperuser(permissions.BasePermission):
     '''Accept only the advisor of the given school with a given assignment.'''
 
@@ -76,3 +77,21 @@ class IsSchoolDelegateAdvisorOrSuperuser(permissions.BasePermission):
 
         return (user.is_authenticated() and user.is_advisor() and
                 user.school.id == delegate.school.id)
+
+
+class AssignmentListPermission(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        if request.user.is_superuser:
+            return True
+
+        if request.method in permissions.SAFE_METHODS:
+            return user_is_advisor(request, view)
+
+        return False
+
+
+def user_is_advisor(request, view):
+    user = request.user
+    school_id = request.GET.get('school_id', -1)
+    return user.is_authenticated() and user.school_id == int(school_id)

--- a/huxley/api/tests/school/test_school_assignments.py
+++ b/huxley/api/tests/school/test_school_assignments.py
@@ -1,80 +1,10 @@
 # Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
-from huxley.api.tests import ListAPITestCase, UpdateAPITestCase
+from huxley.api.tests import UpdateAPITestCase
 from huxley.core.models import Assignment, School
 from huxley.utils.test import (TestCommittees, TestCountries, TestSchools,
                                TestUsers)
-
-
-class SchoolAssignmentsGetTestCase(ListAPITestCase):
-    url_name = 'api:school_assignments'
-    is_resource = True
-
-    def setUp(self):
-        self.user = TestUsers.new_user(username='regular', password='user')
-        self.school = TestSchools.new_school(user=self.user)
-        self.country = TestCountries.new_country()
-        self.committee1 = TestCommittees.new_committee()
-        self.committee2 = TestCommittees.new_committee()
-        self.assignment1 = Assignment.objects.create(
-            committee=self.committee1,
-            country=self.country,
-            school=self.school,
-        )
-        self.assignment2 = Assignment.objects.create(
-            committee=self.committee2,
-            country=self.country,
-            school=self.school,
-        )
-
-    def test_anonymous_user(self):
-        '''It rejects a request from an anonymous user.'''
-        response = self.get_response(self.school.id)
-        self.assertNotAuthenticated(response)
-
-    def test_advisor(self):
-        '''It returns the assignments for the school's advisor.'''
-        self.client.login(username='regular', password='user')
-
-        response = self.get_response(self.school.id)
-        self.assert_assignments_equal(response)
-
-    def test_other_user(self):
-        '''It rejects a request from another user.'''
-        user2 = TestUsers.new_user(username='another', password='user')
-        TestSchools.new_school(user=user2)
-        self.client.login(username='another', password='user')
-
-        response = self.get_response(self.school.id)
-        self.assertPermissionDenied(response)
-
-    def test_superuser(self):
-        '''It returns the assignments for a superuser.'''
-        TestUsers.new_superuser(username='test', password='user')
-        self.client.login(username='test', password='user')
-
-        response = self.get_response(self.school.id)
-        self.assert_assignments_equal(response)
-
-    def assert_assignments_equal(self, response):
-        '''Assert that the response contains the assignments in order.'''
-        self.assertEqual(response.data, [
-            {
-                'id': self.assignment1.id,
-                'country': self.country.id,
-                'committee': self.committee1.id,
-                'school': self.school.id,
-                'rejected': self.assignment1.rejected,
-            },
-            {
-                'id': self.assignment2.id,
-                'country': self.country.id,
-                'committee': self.committee2.id,
-                'school': self.school.id,
-                'rejected': self.assignment2.rejected,
-            },
-        ])
 
 
 class SchoolAssignmentsFinalizeTestCase(UpdateAPITestCase):

--- a/huxley/api/urls.py
+++ b/huxley/api/urls.py
@@ -20,7 +20,6 @@ urlpatterns = [
 
     url(r'^schools/?$', views.school.SchoolList.as_view(), name='school_list'),
     url(r'^schools/(?P<pk>[0-9]+)/?$', views.school.SchoolDetail.as_view(), name='school_detail'),
-    url(r'^schools/(?P<pk>[0-9]+)/assignments/?$', views.school.SchoolAssignments.as_view(), name='school_assignments'),
     url(r'^schools/(?P<pk>[0-9]+)/delegates/?$', views.school.SchoolDelegates.as_view(), name='school_delegates'),
     url(r'^schools/(?P<pk>[0-9]+)/invoice/?$', views.school.SchoolInvoice.as_view(), name='school_invoice'),
 

--- a/huxley/api/views/assignment.py
+++ b/huxley/api/views/assignment.py
@@ -1,26 +1,34 @@
 # Copyright (c) 2011-2015 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
-from rest_framework import generics, status
+from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.response import Response
 
-from huxley.api.permissions import IsSchoolAssignmentAdvisorOrSuperuser, IsSuperuserOrReadOnly
+from huxley.api import permissions
 from huxley.api.serializers import AssignmentSerializer
 from huxley.core.models import Assignment
 
 
-class AssignmentList(generics.CreateAPIView):
+class AssignmentList(generics.ListCreateAPIView):
     authentication_classes = (SessionAuthentication,)
-    queryset = Assignment.objects.all()
-    permission_classes = (IsSuperuserOrReadOnly,)
+    permission_classes = (permissions.AssignmentListPermission,)
     serializer_class = AssignmentSerializer
+
+    def get_queryset(self):
+        queryset = Assignment.objects.all()
+        query_params = self.request.GET
+
+        school_id = query_params.get('school_id', None)
+        if school_id:
+            queryset = queryset.filter(school_id=school_id)
+
+        return queryset
 
 
 class AssignmentDetail(generics.RetrieveUpdateAPIView):
     authentication_classes = (SessionAuthentication,)
     queryset = Assignment.objects.all()
-    permission_classes = (IsSchoolAssignmentAdvisorOrSuperuser,)
+    permission_classes = (permissions.IsSchoolAssignmentAdvisorOrSuperuser,)
     serializer_class = AssignmentSerializer
 
     def put(self, request, *args, **kwargs):

--- a/huxley/api/views/school.py
+++ b/huxley/api/views/school.py
@@ -33,20 +33,6 @@ class SchoolDetail(generics.RetrieveUpdateDestroyAPIView):
         return self.partial_update(request, *args, **kwargs)
 
 
-class SchoolAssignments(generics.ListAPIView):
-    authentication_classes = (SessionAuthentication,)
-    serializer_class = AssignmentSerializer
-    permission_classes = (IsSchoolAdvisorOrSuperuser,)
-
-    def get_queryset(self):
-        '''Filter schools by the given pk param.'''
-        school_id = self.kwargs.get('pk', None)
-        if not school_id:
-            raise Http404
-
-        return Assignment.objects.filter(school_id=school_id)
-
-
 class SchoolDelegates(generics.ListAPIView, ListUpdateModelMixin):
     authentication_classes = (SessionAuthentication,)
     serializer_class = DelegateSerializer

--- a/huxley/www/js/lib/ServerAPI.js
+++ b/huxley/www/js/lib/ServerAPI.js
@@ -23,7 +23,7 @@ var ServerAPI = {
    * Get a list of all assignments for the given school ID.
    */
   getAssignments(schoolID) {
-    return _get(`/api/schools/${schoolID}/assignments`);
+    return _get('/api/assignments', {school_id: schoolID});
   },
 
   /**


### PR DESCRIPTION
This should not be a separate API view; it should instead be a filter on AssignmentList. This merges the two and deletes SchoolAssignments.

Permissions will need to be a bit more complex, so instead of completely general-purpose Permission classes, this proposes a Permission class per-view (when needed), which then delegates to common functions for code reuse.

Tests are updated to verify the filtering behavior, and I inspected the request/response manually in the JS console in the browser.