### PR TITLE
Reincorporates error handling using flux

### DIFF
--- a/huxley/www/js/actions/DelegateActions.js
+++ b/huxley/www/js/actions/DelegateActions.js
@@ -9,10 +9,11 @@ var ActionConstants = require('constants/ActionConstants');
 var Dispatcher = require('dispatcher/Dispatcher');
 
 var DelegateActions = {
-  deleteDelegate(delegateID) {
+  deleteDelegate(delegateID, error) {
     Dispatcher.dispatch({
       actionType: ActionConstants.DELETE_DELEGATE,
-      delegateID: delegateID
+      delegateID: delegateID,
+      error: error,
     });
   },
 
@@ -23,11 +24,12 @@ var DelegateActions = {
     });
   },
 
-  updateDelegate(delegateID, delta) {
+  updateDelegate(delegateID, delta, error) {
     Dispatcher.dispatch({
       actionType: ActionConstants.UPDATE_DELEGATE,
       delegateID: delegateID,
-      delta: delta
+      delta: delta,
+      error: error,
     });
   },
 

--- a/huxley/www/js/actions/DelegateActions.js
+++ b/huxley/www/js/actions/DelegateActions.js
@@ -9,11 +9,11 @@ var ActionConstants = require('constants/ActionConstants');
 var Dispatcher = require('dispatcher/Dispatcher');
 
 var DelegateActions = {
-  deleteDelegate(delegateID, error) {
+  deleteDelegate(delegateID, onError) {
     Dispatcher.dispatch({
       actionType: ActionConstants.DELETE_DELEGATE,
       delegateID: delegateID,
-      error: error,
+      onError: onError,
     });
   },
 
@@ -24,12 +24,12 @@ var DelegateActions = {
     });
   },
 
-  updateDelegate(delegateID, delta, error) {
+  updateDelegate(delegateID, delta, onError) {
     Dispatcher.dispatch({
       actionType: ActionConstants.UPDATE_DELEGATE,
       delegateID: delegateID,
       delta: delta,
-      error: error,
+      onError: onError,
     });
   },
 

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -206,7 +206,7 @@ var AdvisorRosterView = React.createClass({
       `Are you sure you want to delete this delegate (${delegate.name})?`
     );
     if (confirmed) {
-      DelegateActions.deleteDelegate(delegate.id);
+      DelegateActions.deleteDelegate(delegate.id, this._handleDeleteError);
     }
   },
 
@@ -225,7 +225,7 @@ var AdvisorRosterView = React.createClass({
     var user = CurrentUserStore.getCurrentUser();
     this.setState({loading: true});
     var delta = {name: this.state.modal_name, email: this.state.modal_email};
-    DelegateActions.updateDelegate(delegate.id, delta);
+    DelegateActions.updateDelegate(delegate.id, delta, this._handleError);
     event.preventDefault();
   },
 
@@ -237,10 +237,17 @@ var AdvisorRosterView = React.createClass({
     });
   },
 
+  _handleDeleteError: function(response) {
+    window.confirm(
+      `There was an issue processing your request. Please refresh you page and try again.`
+    );
+  },
+
   _handleError: function(response) {
     this.setState({
       errors: response,
-      loading: false
+      loading: false,
+      modal_open: true
     });
   }
 

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -238,7 +238,7 @@ var AdvisorRosterView = React.createClass({
   },
 
   _handleDeleteError: function(response) {
-    window.confirm(
+    alert(
       `There was an issue processing your request. Please refresh you page and try again.`
     );
   },

--- a/huxley/www/js/stores/DelegateStore.js
+++ b/huxley/www/js/stores/DelegateStore.js
@@ -28,8 +28,8 @@ class DelegateStore extends Store {
     return [];
   }
 
-  deleteDelegate(delegateID, error) {
-    ServerAPI.deleteDelegate(delegateID).then(null, error);
+  deleteDelegate(delegateID, onError) {
+    ServerAPI.deleteDelegate(delegateID).catch(onError);
     var schoolID = _delegates[delegateID].school;
     delete _delegates[delegateID];
     _schoolsDelegates[schoolID] = _schoolsDelegates[schoolID].filter(d => d.id !== delegateID);
@@ -40,9 +40,9 @@ class DelegateStore extends Store {
     _schoolsDelegates[delegate.school] = [..._schoolsDelegates[delegate.school], delegate];
   }
 
-  updateDelegate(delegateID, delta, error) {
+  updateDelegate(delegateID, delta, onError) {
     const delegate = {..._delegates[delegateID], ...delta};
-    ServerAPI.updateDelegate(delegateID, delegate).then(null, error);
+    ServerAPI.updateDelegate(delegateID, delegate).catch(onError);
     _delegates[delegateID] = delegate;
     _schoolsDelegates[delegate.school] =
       _schoolsDelegates[delegate.school].map(d => d.id == delegate.id ? delegate : d);
@@ -59,13 +59,13 @@ class DelegateStore extends Store {
   __onDispatch(action) {
     switch (action.actionType) {
       case ActionConstants.DELETE_DELEGATE:
-        this.deleteDelegate(action.delegateID, action.error);
+        this.deleteDelegate(action.delegateID, action.onError);
         break;
       case ActionConstants.ADD_DELEGATE:
         this.addDelegate(action.delegate);
         break;
       case ActionConstants.UPDATE_DELEGATE:
-        this.updateDelegate(action.delegateID, action.delta, action.error);
+        this.updateDelegate(action.delegateID, action.delta, action.onError);
         break;
       case ActionConstants.DELEGATES_FETCHED:
         _schoolsDelegates[action.schoolID] = action.delegates;

--- a/huxley/www/js/stores/DelegateStore.js
+++ b/huxley/www/js/stores/DelegateStore.js
@@ -28,8 +28,8 @@ class DelegateStore extends Store {
     return [];
   }
 
-  deleteDelegate(delegateID) {
-    ServerAPI.deleteDelegate(delegateID);
+  deleteDelegate(delegateID, error) {
+    ServerAPI.deleteDelegate(delegateID).then(null, error);
     var schoolID = _delegates[delegateID].school;
     delete _delegates[delegateID];
     _schoolsDelegates[schoolID] = _schoolsDelegates[schoolID].filter(d => d.id !== delegateID);
@@ -40,9 +40,9 @@ class DelegateStore extends Store {
     _schoolsDelegates[delegate.school] = [..._schoolsDelegates[delegate.school], delegate];
   }
 
-  updateDelegate(delegateID, delta) {
+  updateDelegate(delegateID, delta, error) {
     const delegate = {..._delegates[delegateID], ...delta};
-    ServerAPI.updateDelegate(delegateID, delegate);
+    ServerAPI.updateDelegate(delegateID, delegate).then(null, error);
     _delegates[delegateID] = delegate;
     _schoolsDelegates[delegate.school] =
       _schoolsDelegates[delegate.school].map(d => d.id == delegate.id ? delegate : d);
@@ -59,13 +59,13 @@ class DelegateStore extends Store {
   __onDispatch(action) {
     switch (action.actionType) {
       case ActionConstants.DELETE_DELEGATE:
-        this.deleteDelegate(action.delegateID);
+        this.deleteDelegate(action.delegateID, action.error);
         break;
       case ActionConstants.ADD_DELEGATE:
         this.addDelegate(action.delegate);
         break;
       case ActionConstants.UPDATE_DELEGATE:
-        this.updateDelegate(action.delegateID, action.delta);
+        this.updateDelegate(action.delegateID, action.delta, action.error);
         break;
       case ActionConstants.DELEGATES_FETCHED:
         _schoolsDelegates[action.schoolID] = action.delegates;

--- a/huxley/www/js/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/js/stores/__tests__/DelegateStore-test.js
@@ -35,6 +35,8 @@ describe('DelegateStore', () => {
     mockDelegates = [jake, nate];
 
     ServerAPI.getDelegates.mockReturnValue(Promise.resolve(mockDelegates));
+    ServerAPI.updateDelegate.mockReturnValue(Promise.resolve({}));
+    ServerAPI.deleteDelegate.mockReturnValue(Promise.resolve({}));
   });
 
   it('subscribes to the dispatcher', () => {


### PR DESCRIPTION
The approach to do this is to pass the original error handlers into Actions where those handlers will eventually be called by stores.

For this particular PR I used AdvisorRosterView as an example for what I will do for the remaining views. In it I was unsure of how necessary it was to handle errors when deleting a delegate. I added it for completeness. 

Additionally, something that might be worth considering is when an error is returned from the server, should we automatically roll back those changes in the store? This would probably require firing another action so that the roll back is emitted to the view. If we don't then to the user the change appears implemented (minus the error message thrown) until the page is refreshed.

