### PR TITLE
Set correct contentType on AJAX requests

### DIFF
--- a/huxley/api/mixins.py
+++ b/huxley/api/mixins.py
@@ -4,12 +4,11 @@
 import json
 
 from django.db import transaction
-from django.http import QueryDict
+from rest_framework import status
+from rest_framework.response import Response
 
 from huxley.core.models import Delegate
 
-from rest_framework import status
-from rest_framework.response import Response
 
 class ListUpdateModelMixin(object):
     """
@@ -17,11 +16,7 @@ class ListUpdateModelMixin(object):
     """
 
     def list_update(self, request, partial=False, *args, **kwargs):
-        data = request.data
-        if isinstance(data, QueryDict):
-            data = json.loads(request.data.items()[0][0])
-
-        updates = {delegate['id']: delegate for delegate in data}
+        updates = {delegate['id']: delegate for delegate in request.data}
         response_data = []
 
         with transaction.atomic():

--- a/huxley/api/permissions.py
+++ b/huxley/api/permissions.py
@@ -115,11 +115,7 @@ class DelegateListPermission(permissions.BasePermission):
             if method == 'POST':
                 return int(request.data['school']) == school_id
             else:
-                data = request.data
-                if isinstance(data, QueryDict):
-                    data = json.loads(request.data.items()[0][0])
-
-                delegate_ids = [delegate['id'] for delegate in data]
+                delegate_ids = [delegate['id'] for delegate in request.data]
                 return not Delegate.objects.filter(id__in=delegate_ids).exclude(school_id=school_id).exists()
 
         return False

--- a/huxley/www/js/lib/ServerAPI.js
+++ b/huxley/www/js/lib/ServerAPI.js
@@ -77,7 +77,8 @@ function _ajax(method, uri, data) {
     $.ajax({
       type: method,
       url: uri,
-      data: data,
+      contentType: 'application/json; charset=UTF-8',
+      data: typeof data === 'string' ? data : JSON.stringify(data),
       dataType: 'json',
       success: (data, textStatus, jqXHR) => {
         resolve(jqXHR.responseJSON);

--- a/huxley/www/js/stores/DelegateStore.js
+++ b/huxley/www/js/stores/DelegateStore.js
@@ -49,10 +49,7 @@ class DelegateStore extends Store {
   }
 
   updateDelegates(schoolID, delegates) {
-    ServerAPI.updateSchoolDelegates(
-      schoolID,
-      JSON.stringify(delegates)
-    )
+    ServerAPI.updateSchoolDelegates(schoolID, delegates);
     for (const delegate of delegates) {
       _delegates[delegate.id] = delegate;
     }

--- a/huxley/www/js/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/js/stores/__tests__/DelegateStore-test.js
@@ -161,7 +161,7 @@ describe('DelegateStore', () => {
     expect(callback).toBeCalled();
     expect(ServerAPI.updateSchoolDelegates).toBeCalledWith(
       mockSchoolID,
-      JSON.stringify([updated_jake, udpated_nate])
+      [updated_jake, udpated_nate]
     );
 
     var updated_delegates = DelegateStore.getDelegates(mockSchoolID);


### PR DESCRIPTION
This fixes the need to do the QueryDict hack because it correctly sets the content type on the request, which causes it to be parsed as JSON instead of url-encoded data.

This also adds the JSON stringification in ServerAPI, so we don't have to do it manually in the calls.

Resolves #551.