### PR TITLE
Fixed delegate store with no delegates

### DIFF
--- a/huxley/www/js/components/AdvisorAssignmentsView.js
+++ b/huxley/www/js/components/AdvisorAssignmentsView.js
@@ -81,7 +81,9 @@ var AdvisorAssignmentsView = React.createClass({
 
   render: function() {
     var finalized = CurrentUserStore.getFinalized();
+    var committees = this.state.committees;
     var conference = this.context.conference;
+    var countries = this.state.countries;
     return (
       <InnerView>
         <h2>Assignments</h2>
@@ -112,7 +114,11 @@ var AdvisorAssignmentsView = React.createClass({
                 </tr>
               </thead>
               <tbody>
-                {this.renderAssignmentRows()}
+                {
+                  Object.keys(committees).length > 0 && Object.keys(countries).length > 0 ?
+                  this.renderAssignmentRows() :
+                  <tr></tr>
+                }
               </tbody>
             </table>
           </div>

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -183,6 +183,8 @@ var AdvisorRosterView = React.createClass({
       modal_onClick: fn,
       errors: {}
     });
+  
+    event.preventDefault();
   },
 
   closeModal: function() {

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -183,8 +183,6 @@ var AdvisorRosterView = React.createClass({
       modal_onClick: fn,
       errors: {}
     });
-  
-    event.preventDefault();
   },
 
   closeModal: function() {

--- a/huxley/www/js/stores/AssignmentStore.js
+++ b/huxley/www/js/stores/AssignmentStore.js
@@ -14,13 +14,14 @@ var {Store} = require('flux/utils');
 
 
 var _assignments = {};
+var _assignmentsFetched = false;
 var _previousUserID = -1;
 
 
 class AssignmentStore extends Store {
   getSchoolAssignments(schoolID) {
     var assignmentIDs = Object.keys(_assignments);
-    if (!assignmentIDs.length) {
+    if (!_assignmentsFetched) {
       ServerAPI.getAssignments(schoolID).then(value => {
         AssignmentActions.assignmentsFetched(value);
       });
@@ -33,7 +34,7 @@ class AssignmentStore extends Store {
 
   getCommitteeAssignments(committeeID) {
     var assignmentIDs = Object.keys(_assignments);
-    if (!assignmentIDs.length) {
+    if (!_assignmentsFetched) {
       ServerAPI.getCommitteeAssignments(committeeID).then(value => {
         AssignmentActions.assignmentsFetched(value);
       });
@@ -56,6 +57,7 @@ class AssignmentStore extends Store {
         for (const assignment of action.assignments) {
           _assignments[assignment.id] = assignment;
         }
+        _assignmentsFetched = true;
         break;
       case ActionConstants.UPDATE_ASSIGNMENT:
         this.updateAssignment(action.assignmentID, action.delta, action.onError);
@@ -64,6 +66,7 @@ class AssignmentStore extends Store {
         var userID = CurrentUserStore.getCurrentUser().id;
         if(userID != _previousUserID) {
           _assignments = {};
+          _assignmentsFetched = false;
           _previousUserID = userID;
         }
         break;

--- a/huxley/www/js/stores/DelegateStore.js
+++ b/huxley/www/js/stores/DelegateStore.js
@@ -98,7 +98,7 @@ class DelegateStore extends Store {
         break;
       case ActionConstants.LOGIN:
         var userID = CurrentUserStore.getCurrentUser().id;
-        if(userID != _previousUserID) {
+        if (userID != _previousUserID) {
           _delegates = {};
           _delegatesFetched = false;
           _previousUserID = userID;

--- a/huxley/www/js/stores/DelegateStore.js
+++ b/huxley/www/js/stores/DelegateStore.js
@@ -14,16 +14,15 @@ var {Store} = require('flux/utils');
 
 
 var _delegates = {};
+var _delegatesFetched = false;
 var _previousUserID = -1;
 
 class DelegateStore extends Store {
   getSchoolDelegates(schoolID) {
     var delegateIDs = Object.keys(_delegates);
-    if (!delegateIDs.length) {
+    if (!_delegatesFetched) {
       ServerAPI.getDelegates(schoolID).then(value => {
-        if (value.length) {
-          DelegateActions.delegatesFetched(value);
-        }
+        DelegateActions.delegatesFetched(value);
       });
 
       return [];
@@ -34,7 +33,7 @@ class DelegateStore extends Store {
 
   getCommitteeDelegates(committeeID) {
     var delegateIDs = Object.keys(_delegates);
-    if (!delegateIDs.length) {
+    if (!_delegatesFetched) {
       ServerAPI.getCommitteeDelegates(committeeID).then(value => {
         DelegateActions.delegatesFetched(value);
       });
@@ -89,6 +88,7 @@ class DelegateStore extends Store {
         for (const delegate of action.delegates) {
           _delegates[delegate.id] = delegate;
         }
+        _delegatesFetched = true;
         break;
       case ActionConstants.UPDATE_DELEGATES:
         this.updateDelegates(action.schoolID, action.delegates, action.onError);
@@ -100,6 +100,7 @@ class DelegateStore extends Store {
         var userID = CurrentUserStore.getCurrentUser().id;
         if(userID != _previousUserID) {
           _delegates = {};
+          _delegatesFetched = false;
           _previousUserID = userID;
         }
         break;

--- a/huxley/www/js/stores/__tests__/AssignmentStore-test.js
+++ b/huxley/www/js/stores/__tests__/AssignmentStore-test.js
@@ -14,6 +14,7 @@ describe('AssignmentStore', () => {
   var ServerAPI;
 
   var mockAssignments, mockSchoolID;
+  var mockSchoolID2;
   var registerCallback;
 
   beforeEach(() => {
@@ -28,7 +29,8 @@ describe('AssignmentStore', () => {
       Dispatcher.isDispatching.mockReturnValue(false);
     };
 
-    mockSchoolID = 1
+    mockSchoolID = 1;
+    mockSchoolID2 = 0;
     mockAssignments = [
       {id: 1, school: mockSchoolID, rejected: false},
       {id: 2, school: mockSchoolID, rejected: false}
@@ -53,6 +55,21 @@ describe('AssignmentStore', () => {
 
     assignments = AssignmentStore.getSchoolAssignments(mockSchoolID);
     expect(assignments).toEqual(mockAssignments);
+    expect(ServerAPI.getAssignments.mock.calls.length).toEqual(1);
+  });
+
+  it('differentiates not having fetched assignments from having none', () => {
+    var assignments = AssignmentStore.getSchoolAssignments(mockSchoolID2);
+    expect(assignments.length).toEqual(0);
+    expect(ServerAPI.getAssignments).toBeCalledWith(mockSchoolID2);
+
+    registerCallback({
+      actionType: ActionConstants.ASSIGNMENTS_FETCHED,
+      assignments: []
+    });
+
+    assignments = AssignmentStore.getSchoolAssignments(mockSchoolID2);
+    expect(assignments).toEqual([]);
     expect(ServerAPI.getAssignments.mock.calls.length).toEqual(1);
   });
 

--- a/huxley/www/js/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/js/stores/__tests__/DelegateStore-test.js
@@ -15,7 +15,7 @@ describe('DelegateStore', () => {
 
   var jake, nate
   var mockDelegates, mockSchoolID;
-  var notAnID;
+  var mockSchoolID2;
   var registerCallback;
 
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('DelegateStore', () => {
     };
 
     mockSchoolID = 1;
-    notAnID = 0;
+    mockSchoolID2 = 0;
     jake = {id: 1, name: 'Jake', email: '', school: mockSchoolID};
     nate = {id: 2, name: 'Nate', email: '', school: mockSchoolID};
     mockDelegates = [jake, nate];
@@ -62,16 +62,16 @@ describe('DelegateStore', () => {
   });
 
   it('differentiates no delegates from not having fetched delegates', () => {
-    var delegates = DelegateStore.getSchoolDelegates(notAnID);
+    var delegates = DelegateStore.getSchoolDelegates(mockSchoolID2);
     expect(delegates.length).toEqual(0);
-    expect(ServerAPI.getDelegates).toBeCalledWith(notAnID);
+    expect(ServerAPI.getDelegates).toBeCalledWith(mockSchoolID2);
 
     registerCallback({
       actionType: ActionConstants.DELEGATES_FETCHED,
       delegates: []
     });
 
-    delegates = DelegateStore.getSchoolDelegates(notAnID);
+    delegates = DelegateStore.getSchoolDelegates(mockSchoolID2);
     expect(delegates).toEqual([]);
     expect(ServerAPI.getDelegates.mock.calls.length).toEqual(1);
   });

--- a/huxley/www/js/stores/__tests__/DelegateStore-test.js
+++ b/huxley/www/js/stores/__tests__/DelegateStore-test.js
@@ -15,6 +15,7 @@ describe('DelegateStore', () => {
 
   var jake, nate
   var mockDelegates, mockSchoolID;
+  var notAnID;
   var registerCallback;
 
   beforeEach(() => {
@@ -30,6 +31,7 @@ describe('DelegateStore', () => {
     };
 
     mockSchoolID = 1;
+    notAnID = 0;
     jake = {id: 1, name: 'Jake', email: '', school: mockSchoolID};
     nate = {id: 2, name: 'Nate', email: '', school: mockSchoolID};
     mockDelegates = [jake, nate];
@@ -56,6 +58,21 @@ describe('DelegateStore', () => {
 
     delegates = DelegateStore.getSchoolDelegates(mockSchoolID);
     expect(delegates).toEqual(mockDelegates);
+    expect(ServerAPI.getDelegates.mock.calls.length).toEqual(1);
+  });
+
+  it('differentiates no delegates from not having fetched delegates', () => {
+    var delegates = DelegateStore.getSchoolDelegates(notAnID);
+    expect(delegates.length).toEqual(0);
+    expect(ServerAPI.getDelegates).toBeCalledWith(notAnID);
+
+    registerCallback({
+      actionType: ActionConstants.DELEGATES_FETCHED,
+      delegates: []
+    });
+
+    delegates = DelegateStore.getSchoolDelegates(notAnID);
+    expect(delegates).toEqual([]);
     expect(ServerAPI.getDelegates.mock.calls.length).toEqual(1);
   });
 


### PR DESCRIPTION
This address issue #566 by adding a simple flag to the store to tell whether or not delegates have been fetched. The old version was abusing the existing data by inferring whether data had been fetched using the value in the store and matching no data to having not fetched data.