### PR TITLE
Change table headers not to scroll

### DIFF
--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -81,8 +81,8 @@ var ChairAttendanceView = React.createClass({
           </strong>
         </p>
         <form>
-          <div className="table-container" style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
-            <table className="table highlight-cells">
+          <div className="table-container">
+            <table style={{'margin': '10px auto 0px auto', 'tableLayout':'fixed'}}>
               <thead>
                 <tr>
                   <th>Assignment</th>
@@ -93,15 +93,22 @@ var ChairAttendanceView = React.createClass({
                   <th>Session Four</th>
                 </tr>
               </thead>
-              <tbody>
-                {this.renderAttendanceRows()}
-              </tbody>
             </table>
+            <div style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
+              <table 
+                className="table highlight-cells"
+                style={{'margin': '0px auto 20px auto', 'tableLayout':'fixed'}}
+              >
+                <tbody>
+                  {this.renderAttendanceRows()}
+                </tbody>
+              </table>
+            </div>
           </div>
           <Button
             color="green"
             onClick={this._handleSaveAttendance}>
-            Confirm Attendance
+            Save Attendance
           </Button>
         </form>
       </InnerView>

--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -82,7 +82,7 @@ var ChairAttendanceView = React.createClass({
         </p>
         <form>
           <div className="table-container">
-            <table style={{'margin': '10px auto 0px auto', 'tableLayout':'fixed'}}>
+            <table style={{'margin':'10px auto 0px auto', 'tableLayout':'fixed'}}>
               <thead>
                 <tr>
                   <th>Assignment</th>
@@ -97,7 +97,7 @@ var ChairAttendanceView = React.createClass({
             <div style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
               <table 
                 className="table highlight-cells"
-                style={{'margin': '0px auto 20px auto', 'tableLayout':'fixed'}}
+                style={{'margin':'0px auto 20px auto', 'tableLayout':'fixed'}}
               >
                 <tbody>
                   {this.renderAttendanceRows()}

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -111,23 +111,29 @@ var ChairSummaryView = React.createClass({
           </strong>
         </p>
         <form>
-          <div className="table-container"
-            style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
-            <table className="table highlight-cells">
+          <div className="table-container">
+            <table style={{'margin': '10px auto 0px auto'}}>
               <thead>
                 <tr>
                   <th>Assignment</th>
-                  <th>Summary</th>
+                  <th style={{'width':'65%'}}>Summary</th>
                 </tr>
               </thead>
-              <tbody>
-                {
-                  Object.keys(this.state.countries).length > 0 ?
-                  this.renderSummaryRows() :
-                  <tr></tr>
-                }
-              </tbody>
             </table>
+            <div style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
+              <table
+                className="table highlight-cells"
+                style={{'margin': '0px auto 20px auto'}}
+              >
+                <tbody>
+                  {
+                    Object.keys(this.state.countries).length > 0 ?
+                    this.renderSummaryRows() :
+                    <tr></tr>
+                  }
+                </tbody>
+              </table>
+            </div>
           </div>
           <Button
             color="green"
@@ -156,7 +162,7 @@ var ChairSummaryView = React.createClass({
           <td>
             {countries[assignment.country].name}
           </td>
-          <td>
+          <td style={{'width':'65%'}}>
             <textarea
               className="text-input"
               style={{"width": "95%"}}

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -112,7 +112,7 @@ var ChairSummaryView = React.createClass({
         </p>
         <form>
           <div className="table-container">
-            <table style={{'margin': '10px auto 0px auto'}}>
+            <table style={{'margin':'10px auto 0px auto'}}>
               <thead>
                 <tr>
                   <th>Assignment</th>
@@ -123,7 +123,7 @@ var ChairSummaryView = React.createClass({
             <div style={{'overflowY': 'auto', 'maxHeight': '50vh'}}>
               <table
                 className="table highlight-cells"
-                style={{'margin': '0px auto 20px auto'}}
+                style={{'margin':'0px auto 20px auto'}}
               >
                 <tbody>
                   {


### PR DESCRIPTION
This moves the table headers for the Chair View out of the scrollable div. It's a little hackish; I couldn't find an elegant way to keep the tables together.