### PR TITLE
Only save summaries that have been modified

### DIFF
--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -187,10 +187,14 @@ var ChairSummaryView = React.createClass({
     var committee = CurrentUserStore.getCurrentUser().committee;
     var delegates = this.state.delegates;
     var summaries = this.state.summaries;
+    var toSave = [];
     for (var delegate of delegates) {
-      delegate.summary = summaries[delegate.assignment];
+      if (delegate.summary != summaries[delegate.assignment]) {
+        delegate.summary = summaries[delegate.assignment];
+        toSave.push(delegate);
+      }
     }
-    DelegateActions.updateCommitteeDelegates(committee, delegates);
+    DelegateActions.updateCommitteeDelegates(committee, toSave);
     event.preventDefault();
   },
 
@@ -207,11 +211,16 @@ var ChairSummaryView = React.createClass({
       var committee = CurrentUserStore.getCurrentUser().committee;
       var delegates = this.state.delegates;
       var summaries = this.state.summaries;
+      var toPublish = [];
       for (var delegate of delegates) {
-        delegate.summary = summaries[delegate.assignment];
+        var summary = summaries[delegate.assignment];
+        if (delegate.summary != summary || delegate.published_summary != summary) {
+          delegate.summary = summaries[delegate.assignment];
+          delegate.published_summary = delegate.summary;
+          toPublish.push(delegate);
+        }
       }
-      delegates.forEach(delegate => delegate.published_summary = delegate.summary);
-      DelegateActions.updateCommitteeDelegates(committee, delegates);
+      DelegateActions.updateCommitteeDelegates(committee, toPublish);
       event.preventDefault();
     }
   },

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -192,7 +192,7 @@ var ChairSummaryView = React.createClass({
       var summary = summaries[delegate.assignment];
       if (delegate.summary != summary) {
         var update = {summary:summary};
-        toSave.push(Object.assign({}, delegate, update));
+        toSave.push({...delegate, ...update});
       }
     }
     DelegateActions.updateCommitteeDelegates(committee, toSave);
@@ -217,7 +217,7 @@ var ChairSummaryView = React.createClass({
         var summary = summaries[delegate.assignment];
         if (delegate.summary != summary || delegate.published_summary != summary) {
           var update = {summary:summary, published_summary:summary};
-          toPublish.push(Object.assign({}, delegate, update));
+          toPublish.push({...delegate, ...update});
         }
       }
       DelegateActions.updateCommitteeDelegates(committee, toPublish);

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -198,7 +198,6 @@ var ChairSummaryView = React.createClass({
     event.preventDefault();
   },
 
-
   _handlePublishSummaries(event) {
     var confirm = window.confirm("By pressing ok, you are allowing advisors " +
                                  "to read the summaries that you have written " +

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -198,6 +198,7 @@ var ChairSummaryView = React.createClass({
     event.preventDefault();
   },
 
+
   _handlePublishSummaries(event) {
     var confirm = window.confirm("By pressing ok, you are allowing advisors " +
                                  "to read the summaries that you have written " +
@@ -216,7 +217,7 @@ var ChairSummaryView = React.createClass({
         var summary = summaries[delegate.assignment];
         if (delegate.summary != summary || delegate.published_summary != summary) {
           delegate.summary = summaries[delegate.assignment];
-          delegate.published_summary = delegate.summary;
+          delegate.published_summary = summaries[delegate.assignment];
           toPublish.push(delegate);
         }
       }

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -189,9 +189,10 @@ var ChairSummaryView = React.createClass({
     var summaries = this.state.summaries;
     var toSave = [];
     for (var delegate of delegates) {
-      if (delegate.summary != summaries[delegate.assignment]) {
-        delegate.summary = summaries[delegate.assignment];
-        toSave.push(delegate);
+      var summary = summaries[delegate.assignment];
+      if (delegate.summary != summary) {
+        var update = {summary:summary};
+        toSave.push(Object.assign({}, delegate, update));
       }
     }
     DelegateActions.updateCommitteeDelegates(committee, toSave);
@@ -215,9 +216,8 @@ var ChairSummaryView = React.createClass({
       for (var delegate of delegates) {
         var summary = summaries[delegate.assignment];
         if (delegate.summary != summary || delegate.published_summary != summary) {
-          delegate.summary = summaries[delegate.assignment];
-          delegate.published_summary = summaries[delegate.assignment];
-          toPublish.push(delegate);
+          var update = {summary:summary, published_summary:summary};
+          toPublish.push(Object.assign({}, delegate, update));
         }
       }
       DelegateActions.updateCommitteeDelegates(committee, toPublish);

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -191,8 +191,7 @@ var ChairSummaryView = React.createClass({
     for (var delegate of delegates) {
       var summary = summaries[delegate.assignment];
       if (delegate.summary != summary) {
-        var update = {summary:summary};
-        toSave.push({...delegate, ...update});
+        toSave.push({...delegate, summary});
       }
     }
     DelegateActions.updateCommitteeDelegates(committee, toSave);
@@ -216,8 +215,7 @@ var ChairSummaryView = React.createClass({
       for (var delegate of delegates) {
         var summary = summaries[delegate.assignment];
         if (delegate.summary != summary || delegate.published_summary != summary) {
-          var update = {summary:summary, published_summary:summary};
-          toPublish.push({...delegate, ...update});
+          toPublish.push({...delegate, summary, published_summary: summary});
         }
       }
       DelegateActions.updateCommitteeDelegates(committee, toPublish);


### PR DESCRIPTION
This makes it so that when a chair saves summaries, only the delegates that have had their summaries updated get sent to the backend. This helps with letting multiple chairs access the page at once, as now only changes made to the same delegates' summaries would get clobbered (versus before, where every summary for the committee would get clobbered).