### PR TITLE
Split JS into app/vendor bundles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ htmlcov/
 node_modules/
 
 huxley/www/static/js/bundle.js
+huxley/www/static/js/huxley.js
+huxley/www/static/js/vendor.js
 huxley/www/static/js/bundle.css

--- a/huxley/www/templates/www.html
+++ b/huxley/www/templates/www.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" href="/static/img/favicon.png" />
     {% load static %}
     <link type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,700,600,400,300" rel="stylesheet">
-    <link type="text/css" href="{% static 'js/bundle.css' %}" rel="stylesheet">
+    <link type="text/css" href="{% static 'js/huxley.css' %}" rel="stylesheet">
     <script type="text/javascript">
         currentUser = {{ user_json|safe }};
         conference = {{ conference_json|safe }}
@@ -16,7 +16,8 @@
         ContactTypes = {{ contact_types|safe }};
         ProgramTypes = {{ program_types|safe }};
     </script>
-    <script type="text/javascript" src="{% static 'js/bundle.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/vendor.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/huxley.js' %}"></script>
 </head>
 <body>
     {% include "ie-warning.html" %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,11 @@ var plugins = [
   new webpack.EnvironmentPlugin([
     'NODE_ENV',
   ]),
-  new ExtractTextPlugin('bundle.css'),
+  new ExtractTextPlugin('huxley.css'),
+  new webpack.optimize.CommonsChunkPlugin({
+    name: 'vendor',
+    filename: 'vendor.js',
+  }),
 ];
 if (process.env.NODE_ENV === 'production') {
   plugins.push(
@@ -25,10 +29,23 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 module.exports = {
-  entry: path.join(JS_ROOT, 'entry.js'),
+  entry: {
+    huxley: path.join(JS_ROOT, 'entry.js'),
+    vendor: [
+      'classnames',
+      'flux',
+      'jquery',
+      'jquery-ui',
+      'js-cookie',
+      'react',
+      'react-dom',
+      'react-modal',
+      'react-router',
+    ],
+  },
   output: {
     path: STATIC_ROOT,
-    filename: 'bundle.js',
+    filename: '[name].js',
   },
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ var webpack = require('webpack');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+var package = require('./package.json');
+
 var JS_ROOT = path.join(__dirname, 'huxley/www/js');
 var STATIC_ROOT = path.join(__dirname, 'huxley/www/static/js');
 
@@ -31,17 +33,7 @@ if (process.env.NODE_ENV === 'production') {
 module.exports = {
   entry: {
     huxley: path.join(JS_ROOT, 'entry.js'),
-    vendor: [
-      'classnames',
-      'flux',
-      'jquery',
-      'jquery-ui',
-      'js-cookie',
-      'react',
-      'react-dom',
-      'react-modal',
-      'react-router',
-    ],
+    vendor: Object.keys(package.dependencies),
   },
   output: {
     path: STATIC_ROOT,


### PR DESCRIPTION
This separates our app code from our dependency code. Because dependencies change a lot less frequently than the app, this allows the users' browsers to cache the vendor bundle, so that it loads faster on subsequent requests.

One minor downside is that when we add/remove dependencies, we also need to update the list in the Webpack config.

Resolves #508.