### PR TITLE
Use CSS animation to shake instead of jQuery.

### DIFF
--- a/huxley/www/js/components/AdvisorProfileView.js
+++ b/huxley/www/js/components/AdvisorProfileView.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var $ = require('jquery');
 var React = require('react');
 
 var Button = require('components/Button');

--- a/huxley/www/js/components/AdvisorProfileView.js
+++ b/huxley/www/js/components/AdvisorProfileView.js
@@ -21,7 +21,6 @@ var User = require('utils/User');
 var _handleChange = require('utils/_handleChange');
 
 require('css/Table.less');
-require('jquery-ui/effect-shake');
 
 var AdvisorProfileView = React.createClass({
 
@@ -34,7 +33,8 @@ var AdvisorProfileView = React.createClass({
   // },
 
   contextTypes: {
-    conference: React.PropTypes.shape(ConferenceContext)
+    conference: React.PropTypes.shape(ConferenceContext),
+    shake: React.PropTypes.func,
   },
 
   getInitialState: function() {
@@ -390,12 +390,8 @@ var AdvisorProfileView = React.createClass({
     this.setState({
       errors: response,
       loading: false
-    }, function() {
-      $('#huxley-app').effect(
-        'shake',
-        {direction: 'up', times: 2},
-        250
-      );
+    }, () => {
+      this.context.shake && this.context.shake();
     });
   }
 });

--- a/huxley/www/js/components/AdvisorView.js
+++ b/huxley/www/js/components/AdvisorView.js
@@ -10,6 +10,7 @@ var ReactRouter = require('react-router');
 
 var NavTab = require('components/NavTab');
 var PermissionDeniedView = require('components/PermissionDeniedView');
+var Shaker = require('components/Shaker');
 var TopBar = require('components/TopBar');
 var User = require('utils/User');
 
@@ -32,21 +33,23 @@ var AdvisorView = React.createClass ({
     return (
       <div>
         <TopBar user={this.props.user} />
-        <div className="navbar rounded-top">
-          <NavTab href="/advisor/profile">
-            Profile
-          </NavTab>
-          <NavTab href="/advisor/assignments">
-            Assignments
-          </NavTab>
-          <NavTab href="/advisor/roster">
-            Delegates
-          </NavTab>
-          <NavTab href="/advisor/feedback">
-            Feedback
-          </NavTab>
-        </div>
-        {this.props.children}
+        <Shaker>
+          <div className="navbar rounded-top">
+            <NavTab href="/advisor/profile">
+              Profile
+            </NavTab>
+            <NavTab href="/advisor/assignments">
+              Assignments
+            </NavTab>
+            <NavTab href="/advisor/roster">
+              Delegates
+            </NavTab>
+            <NavTab href="/advisor/feedback">
+              Feedback
+            </NavTab>
+          </div>
+          {this.props.children}
+        </Shaker>
       </div>
     );
   },

--- a/huxley/www/js/components/ChairView.js
+++ b/huxley/www/js/components/ChairView.js
@@ -8,6 +8,7 @@
 var React = require('react');
 
 var NavTab = require('components/NavTab');
+var Shaker = require('components/Shaker');
 var TopBar = require('components/TopBar');
 
 require('css/NavBar.less');
@@ -17,15 +18,17 @@ var ChairView = React.createClass({
     return (
       <div>
         <TopBar user={this.props.user} />
-        <div className="navbar rounded-top">
-          <NavTab href="/chair/attendance">
-            Attendance
-          </NavTab>
-          <NavTab href="/chair/summary">
-            Summaries
-          </NavTab>
-        </div>
-        {this.props.children}
+        <Shaker>
+          <div className="navbar rounded-top">
+            <NavTab href="/chair/attendance">
+              Attendance
+            </NavTab>
+            <NavTab href="/chair/summary">
+              Summaries
+            </NavTab>
+          </div>
+          {this.props.children}
+        </Shaker>
       </div>
     );
   },

--- a/huxley/www/js/components/ForgotPasswordView.js
+++ b/huxley/www/js/components/ForgotPasswordView.js
@@ -17,12 +17,15 @@ var StatusLabel = require('components/StatusLabel');
 var TextInput = require('components/TextInput');
 
 require('css/LoginForm.less');
-require('jquery-ui/effect-shake');
 
 var ForgotPasswordView = React.createClass({
   mixins: [
     ReactRouter.History,
   ],
+
+  contextTypes: {
+    shake: React.PropTypes.func,
+  },
 
   getInitialState: function() {
     return {
@@ -80,7 +83,7 @@ var ForgotPasswordView = React.createClass({
 
   _handleSubmit: function(event) {
     this.setState({loading: true});
-    ServerAPI.resetPassword(username).then(
+    ServerAPI.resetPassword(this.state.username).then(
       this._handleSuccess,
       this._handleError,
     );
@@ -100,11 +103,7 @@ var ForgotPasswordView = React.createClass({
       error: "Sorry, we couldn't find a user with that username.",
       loading: false
     }, () => {
-      $('#huxley-app').effect(
-        'shake',
-        {direction: 'up', times: 2, distance: 2},
-        250
-      );
+      this.context.shake && this.context.shake();
     });
   },
 });

--- a/huxley/www/js/components/ForgotPasswordView.js
+++ b/huxley/www/js/components/ForgotPasswordView.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var $ = require('jquery');
 var React = require('react');
 var ReactRouter = require('react-router');
 

--- a/huxley/www/js/components/Huxley.js
+++ b/huxley/www/js/components/Huxley.js
@@ -12,6 +12,7 @@ var AdvisorView = require('components/AdvisorView');
 var ChairView = require('components/ChairView');
 var ConferenceContext = require('components/ConferenceContext');
 var CurrentUserStore = require('stores/CurrentUserStore');
+var Shaker = require('components/Shaker');
 var User = require('utils/User');
 
 require('css/base.less');
@@ -49,7 +50,11 @@ var Huxley = React.createClass({
   render: function() {
     var user = CurrentUserStore.getCurrentUser();
     if (User.isAnonymous(user)) {
-      return React.cloneElement(this.props.children, { user: user });
+      return (
+        <Shaker>
+          {React.cloneElement(this.props.children, { user: user })}
+        </Shaker>
+      );
     } else if (User.isAdvisor(user)) {
       return (
         <AdvisorView user={user}>

--- a/huxley/www/js/components/LoginView.js
+++ b/huxley/www/js/components/LoginView.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var $ = require('jquery');
 var cx = require('classnames');
 var React = require('react');
 var ReactRouter = require('react-router');
@@ -21,7 +20,6 @@ var TextInput = require('components/TextInput');
 var User = require('utils/User');
 
 require('css/LoginForm.less');
-require('jquery-ui/effect-shake');
 
 var LoginView = React.createClass({
   mixins: [
@@ -29,7 +27,8 @@ var LoginView = React.createClass({
   ],
 
   contextTypes: {
-    conference: React.PropTypes.shape(ConferenceContext)
+    conference: React.PropTypes.shape(ConferenceContext),
+    shake: React.PropTypes.func,
   },
 
   getInitialState: function() {
@@ -149,11 +148,7 @@ var LoginView = React.createClass({
       error: responseJSON.detail,
       loading: false,
     }, () => {
-      $('#huxley-app').effect(
-        'shake',
-        {direction: 'up', times: 2, distance: 2},
-        250
-      );
+      this.context.shake && this.context.shake();
     });
   }
 });

--- a/huxley/www/js/components/RegistrationView.js
+++ b/huxley/www/js/components/RegistrationView.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var $ = require('jquery');
 var cx = require('classnames');
 var React = require('react');
 var ReactRouter = require('react-router');
@@ -28,7 +27,6 @@ var TextInput = require('components/TextInput');
 var _handleChange = require('utils/_handleChange');
 
 require('css/RegistrationView.less');
-require('jquery-ui/effect-shake');
 
 var USA = 'United States of America';
 
@@ -38,7 +36,8 @@ var RegistrationView = React.createClass({
   ],
 
   contextTypes: {
-    conference: React.PropTypes.shape(ConferenceContext)
+    conference: React.PropTypes.shape(ConferenceContext),
+    shake: React.PropTypes.func,
   },
 
   getInitialState: function() {
@@ -674,13 +673,9 @@ var RegistrationView = React.createClass({
     this.setState({
       errors: response,
       loading: false
-    }, function() {
-      $('#huxley-app').effect(
-        'shake',
-        {direction: 'up', times: 2, distance: 2},
-        250
-      );
-    }.bind(this));
+    }, () => {
+      this.context.shake && this.context.shake();
+    });
   }
 });
 

--- a/huxley/www/js/components/Shaker.js
+++ b/huxley/www/js/components/Shaker.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2011-2017 Berkeley Model United Nations. All rights reserved.
+ * Use of this source code is governed by a BSD License (see LICENSE).
+ */
+
+'use strict';
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+
+var cx = require('classnames');
+
+require('css/Shaker.less');
+
+var Shaker = React.createClass({
+  childContextTypes: {
+    shake: React.PropTypes.func,
+  },
+
+  getChildContext() {
+    return {
+      shake: this.shake,
+    };
+  },
+
+  render() {
+    return (
+      <div className={cx('shaker', this.props.className)}>
+        {this.props.children}
+      </div>
+    );
+  },
+
+  shake() {
+    const element = ReactDOM.findDOMNode(this);
+    if (element) {
+      this._timeout && clearTimeout(this._timeout);
+      element.classList.remove('shake');
+      element.classList.add('shake');
+      this._timeout = setTimeout(() => {
+        element.classList.remove('shake');
+      }, 301);
+    }
+  },
+});
+
+module.exports = Shaker;

--- a/huxley/www/js/css/Shaker.less
+++ b/huxley/www/js/css/Shaker.less
@@ -1,0 +1,22 @@
+@keyframes shake {
+  from, to {
+    transform: translate3d(0, 0, 0);
+  }
+
+  20%, 60% {
+    transform: translate3d(-4px, 0, 0);
+  }
+
+  40%, 80% {
+    transform: translate3d(4px, 0, 0);
+  }
+}
+
+.shaker {
+  animation-duration: 0.3s;
+  animation-fill-mode: both;
+
+  &.shake {
+    animation-name: shake;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "flux": "^2.1.1",
     "fbjs": "0.8.3",
     "jquery": "2.1.1",
-    "jquery-ui": "1.10.5",
     "js-cookie": "~2.0.3",
     "react": "15.0.0",
     "react-dom": "15.0.0",


### PR DESCRIPTION
This ditches jQuery for the "shake" error animation throughout the app. Instead, we use CSS animations inspired by https://github.com/daneden/animate.css. There's a top level Shaker component, which provides a `shake` method through context. That way, any child can trigger a shake. Resolves #337.