### PR TITLE
added history dependency and updated gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ htmlcov/
 node_modules/
 
 huxley/www/static/js/bundle.js
+huxley/www/static/js/bundle.css

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "license": "BSD",
   "dependencies": {
     "classnames": "2.2.5",
-    "flux": "^2.1.1",
     "fbjs": "0.8.3",
+    "flux": "^2.1.1",
+    "history": "^1.12.0",
     "jquery": "2.1.1",
     "jquery-ui": "1.10.5",
     "js-cookie": "~2.0.3",


### PR DESCRIPTION
When running `npm install` I received this warning
```
npm WARN react-router@1.0.0 requires a peer of history@^1.12.0 but none was installed.
```

So I went ahead and added the dependency.

Also added `huxley/www/static/js/bundle.css` to the gitignore because it looks like it's generated when we run the build.