### PR TITLE
Use window.fetch polyfill in ServerAPI.

### DIFF
--- a/huxley/www/js/stores/CountryStore.js
+++ b/huxley/www/js/stores/CountryStore.js
@@ -21,7 +21,6 @@ class CountryStore extends Store {
     }
 
     ServerAPI.getCountries().then(value => {
-      debugger;
       CountryActions.countriesFetched(value);
     });
 

--- a/huxley/www/js/stores/CountryStore.js
+++ b/huxley/www/js/stores/CountryStore.js
@@ -21,6 +21,7 @@ class CountryStore extends Store {
     }
 
     ServerAPI.getCountries().then(value => {
+      debugger;
       CountryActions.countriesFetched(value);
     });
 

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "fbjs": "0.8.3",
     "flux": "^2.1.1",
     "history": "^1.12.0",
-    "jquery": "2.1.1",
     "js-cookie": "~2.0.3",
     "react": "15.0.0",
     "react-dom": "15.0.0",
     "react-modal": "1.4.0",
-    "react-router": "1.0.0"
+    "react-router": "1.0.0",
+    "whatwg-fetch": "^2.0.3"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This uses GitHub's  polyfill in favor of jQuery. With this final part complete, we can finally get rid of jQuery completely!

Since this is a lower-level API, we had to do some things manually:
- If the request is a safe method, we generate the query string
- We have to specify that we want to send the cookie with the  param
- The Promise returned from  doesn't reject if there's an error, so we had to do it ourselves.

Resolves #388.