### PR TITLE
Introduces prettier and fixes autoformatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Huxley is a web application designed to manage the annual [Berkeley Model United Nations](http://bmun.org/) conference.
 
 [![Build Status](https://travis-ci.org/bmun/huxley.svg?branch=master)](https://travis-ci.org/bmun/huxley)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+
 
 ## About BMUN
 The Berkeley Model United Nations conference is a high-school conference hosted every spring. Each year, we host over 1500 delegates from all over the country (and the world!), who compete in a simulation of the United Nations and other international/historical bodies to solve the world's most compelling problems.

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -86,9 +86,10 @@ def format_python(py_diff_list):
 def format_js(source):
     '''Formats the javascript files in source using prettier. The argument
        source is a string where each file path is separated by a space.'''
-    options = '--trailing-comma all --jsx-bracket-same-line --no-bracket-spacing'
-    local('./node_modules/.bin/prettier ' + options + ' --debug-check ' + source)
-    local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
+    if len(source) > 0:
+        options = '--trailing-comma all --jsx-bracket-same-line --no-bracket-spacing'
+        local('./node_modules/.bin/prettier ' + options + ' --debug-check ' + source)
+        local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
 
 
 @task

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -55,10 +55,21 @@ def lint():
 
 @task
 def format():
-    '''Format and commit python files committed on the current feature branch'''
-    diff_list = git.diff_name_only()
+    '''Format files committed on the current feature branch'''
+    diff_list = git.diff_name_only(options='--diff-filter=d')
     py_diff_list = [pyfile for pyfile in diff_list if pyfile.endswith('.py')]
+    format_python(py_diff_list)
 
+    js_source = ' '.join([jsfile for jsfile in diff_list if jsfile.endswith('.js')])
+    format_js(js_source)
+    print ui.info('Formatting complete')
+
+    if len(local('git status --porcelain', capture=True)) > 0:
+        local('git commit -am "Ran autoformatter"')
+
+
+@task
+def format_python(py_diff_list):
     if confirm('Review formatting changes? (Select no to approve all)'):
 
         for pyfile in py_diff_list:
@@ -68,10 +79,15 @@ def format():
     else:
         for pyfile in py_diff_list:
             FormatFile(pyfile, in_place=True)
-    print ui.info('Formatting complete')
 
-    if len(local('git status --porcelain', capture=True)) > 0:
-        local('git commit -am "Ran autoformatter"')
+
+@task
+def format_js(source):
+    '''Formats the javascript files in source using prettier. The argument
+       source is a string where each file path is separated by a space.'''
+    if len(source) > 0:
+        options = '--trailing-comma all'
+        local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
 
 
 @task
@@ -82,7 +98,7 @@ def submit(remote='origin', skip_tests=False):
         if not confirm('Continue submit?'):
             return
 
-    # format()
+    format()
     if not skip_tests:
         with settings(warn_only=True):
             if not test.run():

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -86,9 +86,9 @@ def format_python(py_diff_list):
 def format_js(source):
     '''Formats the javascript files in source using prettier. The argument
        source is a string where each file path is separated by a space.'''
-    if len(source) > 0:
-        options = '--trailing-comma all --jsx-bracket-same-line --no-bracket-spacing'
-        local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
+    options = '--trailing-comma all --jsx-bracket-same-line --no-bracket-spacing'
+    local('./node_modules/.bin/prettier ' + options + ' --debug-check ' + source)
+    local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
 
 
 @task

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -60,7 +60,8 @@ def format():
     py_diff_list = [pyfile for pyfile in diff_list if pyfile.endswith('.py')]
     format_python(py_diff_list)
 
-    js_source = ' '.join([jsfile for jsfile in diff_list if jsfile.endswith('.js')])
+    js_source = ' '.join(
+        [jsfile for jsfile in diff_list if jsfile.endswith('.js')])
     format_js(js_source)
     print ui.info('Formatting complete')
 

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -87,7 +87,7 @@ def format_js(source):
     '''Formats the javascript files in source using prettier. The argument
        source is a string where each file path is separated by a space.'''
     if len(source) > 0:
-        options = '--trailing-comma all'
+        options = '--trailing-comma all --jsx-bracket-same-line --no-bracket-spacing'
         local('./node_modules/.bin/prettier ' + options + ' --write ' + source)
 
 

--- a/fabfile/utils/git.py
+++ b/fabfile/utils/git.py
@@ -61,10 +61,10 @@ def hub_installed():
         return local('hub').return_code != 127
 
 
-def diff_name_only(remote='upstream', branch='master'):
+def diff_name_only(remote='upstream', branch='master', options=''):
     with hide('running'):
         diff_list = local(
-            'git diff --name-only %s/%s...HEAD' % (remote, branch),
+            'git diff --name-only %s %s/%s...HEAD' % (options, remote, branch),
             capture=True)
     return diff_list.split('\n')
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "less": "^2.7.2",
     "less-loader": "^4.0.3",
     "markdown-loader": "^2.0.0",
+    "prettier": "^1.5.3",
     "style-loader": "^0.16.1",
     "uglify-js": "~2.4.15",
     "webpack": "^2.4.1"


### PR DESCRIPTION
This PR addresses #600 and #550 

To introduce prettier, I created a fab command that should be our only way to invoke prettier. Therefore, whether calling prettier on a standalone file from the command line or integrating it into our fabric workflow we maintain consistency with the options we specify in the command.

As for the options themselves, explicitly this is how the current configuration will format for us:
- line length of 80 characters
- 2 spaces per indentation-level
- indents with spaces rather than tabs
- adds a semi-colon at the end of every statement
- double quotes
- trailing commas wherever possible
- print spaces between brackets in object literals
- Put the `>` of a multi-line JSX element alone on the next line instead of at the end of the last line

Reference source for options is [here](https://github.com/prettier/prettier#options). If there is anything we need to change here, I'll push up in the next diff.

Additionally, I believe the autoformatter was throwing on a deleted file because we were formatting a file that doesn't exist anymore and then trying to commit on it. I haven't tested the fix I introduced yet.