### PR TITLE
Clean up ChairView code

### DIFF
--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -79,7 +79,7 @@ var ChairAttendanceView = React.createClass({
       }
       this.setState({
         delegates: delegates,
-        attendance: Object.assign({}, attendance, update),
+        attendance: {...attendance, ...update}),
       });
     });
 
@@ -176,11 +176,11 @@ var ChairAttendanceView = React.createClass({
   _handleAttendanceChange(field, assignmentID, event) {
     var attendanceMap = this.state.attendance;
     var oldAttendance = attendanceMap[assignmentID];
-    var newAttendance = Object.assign({}, oldAttendance);
+    var newAttendance = {...oldAttendance};
     newAttendance[field] = !newAttendance[field];
     var update = {};
     update[assignmentID] = newAttendance;
-    this.setState({attendance: Object.assign({}, attendanceMap, update)});
+    this.setState({attendance: {...attendanceMap, ...update}});
   },
 
   _handleSaveAttendance(event) {
@@ -198,7 +198,7 @@ var ChairAttendanceView = React.createClass({
                       session_two: attendance["session_two"],
                       session_three: attendance["session_three"],
                       session_four: attendance["session_four"]};
-        toSave.push(Object.assign({}, delegate, update))
+        toSave.push({...delegate, ...update})
       }
     }
     DelegateActions.updateCommitteeDelegates(committee, toSave, this._handleSuccess, this._handleError);

--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -50,7 +50,7 @@ var ChairAttendanceView = React.createClass({
       assignments: assignments,
       countries: countries,
       delegates: delegates,
-      attendance: attendance,
+      attendance: attendance
     };
   },
 

--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -79,7 +79,7 @@ var ChairAttendanceView = React.createClass({
       }
       this.setState({
         delegates: delegates,
-        attendance: {...attendance, ...update}),
+        attendance: {...attendance, ...update},
       });
     });
 

--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -31,18 +31,23 @@ var ChairAttendanceView = React.createClass({
     var countries = CountryStore.getCountries();
     var delegates = DelegateStore.getCommitteeDelegates(user.committee);
     var attendance = {};
+    if (assignments.length && Object.keys(countries).length) {
+      assignments.sort(
+        (a1, a2) =>
+          countries[a1.country].name < countries[a2.country].name ? -1 : 1,
+      );
+    }
+
     for (var delegate of delegates) {
       var delegateAttendance = {};
-      delegateAttendance["voting"] = delegate.voting;
-      delegateAttendance["session_one"] = delegate.session_one;
-      delegateAttendance["session_two"] = delegate.session_two;
-      delegateAttendance["session_three"] = delegate.session_three;
-      delegateAttendance["session_four"] = delegate.session_four;
+      delegateAttendance['voting'] = delegate.voting;
+      delegateAttendance['session_one'] = delegate.session_one;
+      delegateAttendance['session_two'] = delegate.session_two;
+      delegateAttendance['session_three'] = delegate.session_three;
+      delegateAttendance['session_four'] = delegate.session_four;
       attendance[delegate.assignment] = delegateAttendance;
     }
-    if (assignments.length && Object.keys(countries).length){
-      assignments.sort((a1, a2) => countries[a1.country].name < countries[a2.country].name ? -1 : 1);
-    }
+
     return {
       country_assignments: {},
       loading: false,
@@ -50,7 +55,7 @@ var ChairAttendanceView = React.createClass({
       assignments: assignments,
       countries: countries,
       delegates: delegates,
-      attendance: attendance
+      attendance: attendance,
     };
   },
 
@@ -66,15 +71,15 @@ var ChairAttendanceView = React.createClass({
     var attendance = this.state.attendance;
 
     this._delegatesToken = DelegateStore.addListener(() => {
-      var delegates =  DelegateStore.getCommitteeDelegates(user.committee);
+      var delegates = DelegateStore.getCommitteeDelegates(user.committee);
       var update = {};
       for (var delegate of delegates) {
         var delegateAttendance = {};
-        delegateAttendance["voting"] = delegate.voting;
-        delegateAttendance["session_one"] = delegate.session_one;
-        delegateAttendance["session_two"] = delegate.session_two;
-        delegateAttendance["session_three"] = delegate.session_three;
-        delegateAttendance["session_four"] = delegate.session_four;
+        delegateAttendance['voting'] = delegate.voting;
+        delegateAttendance['session_one'] = delegate.session_one;
+        delegateAttendance['session_two'] = delegate.session_two;
+        delegateAttendance['session_three'] = delegate.session_three;
+        delegateAttendance['session_four'] = delegate.session_four;
         update[delegate.assignment] = delegateAttendance;
       }
       this.setState({
@@ -87,7 +92,10 @@ var ChairAttendanceView = React.createClass({
       var assignments = AssignmentStore.getCommitteeAssignments(user.committee);
       var countries = this.state.countries;
       if (Object.keys(countries).length) {
-        assignments.sort((a1, a2) => countries[a1.country].name < countries[a2.country].name ? -1 : 1);
+        assignments.sort(
+          (a1, a2) =>
+            countries[a1.country].name < countries[a2.country].name ? -1 : 1,
+        );
       }
       this.setState({assignments: assignments});
     });
@@ -96,11 +104,14 @@ var ChairAttendanceView = React.createClass({
       var assignments = this.state.assignments;
       var countries = CountryStore.getCountries();
       if (assignments.length) {
-        assignments.sort((a1, a2) => countries[a1.country].name < countries[a2.country].name ? -1 : 1);
+        assignments.sort(
+          (a1, a2) =>
+            countries[a1.country].name < countries[a2.country].name ? -1 : 1,
+        );
       }
       this.setState({
         assignments: assignments,
-        countries: countries
+        countries: countries,
       });
     });
   },
@@ -110,6 +121,7 @@ var ChairAttendanceView = React.createClass({
     this._countriesToken && this._countriesToken.remove();
     this._delegatesToken && this._delegatesToken.remove();
     this._assignmentsToken && this._assignmentsToken.remove();
+    this._successTimeout && clearTimeout(this._successTimeout);
   },
 
   render() {
@@ -159,17 +171,21 @@ var ChairAttendanceView = React.createClass({
     var attendance = this.state.attendance;
     var assignmentIDs = Object.keys(attendance);
     var countries = this.state.countries;
-    assignments = assignments.filter(a => assignmentIDs.indexOf(""+a.id) > -1);
-    return assignments.map(assignment => 
+    assignments = assignments.filter(
+      a => assignmentIDs.indexOf('' + a.id) > -1,
+    );
+    return assignments.map(assignment =>
       <DelegationAttendanceRow
         key={assignment.id}
         onChange={this._handleAttendanceChange}
         countryName={
-          Object.keys(countries).length ? countries[assignment.country].name : ""+assignment.country
+          Object.keys(countries).length
+            ? countries[assignment.country].name
+            : '' + assignment.country
         }
         assignmentID={assignment.id}
         attendance={attendance[assignment.id]}
-      />
+      />,
     );
   },
 
@@ -193,15 +209,22 @@ var ChairAttendanceView = React.createClass({
     for (var delegate of delegates) {
       var attendance = attendanceMap[delegate.assignment];
       if (delegate.attendance != attendance) {
-        var update = {voting: attendance["voting"],
-                      session_one: attendance["session_one"],
-                      session_two: attendance["session_two"],
-                      session_three: attendance["session_three"],
-                      session_four: attendance["session_four"]};
-        toSave.push({...delegate, ...update})
+        var update = {
+          voting: attendance['voting'],
+          session_one: attendance['session_one'],
+          session_two: attendance['session_two'],
+          session_three: attendance['session_three'],
+          session_four: attendance['session_four'],
+        };
+        toSave.push({...delegate, ...update});
       }
     }
-    DelegateActions.updateCommitteeDelegates(committee, toSave, this._handleSuccess, this._handleError);
+    DelegateActions.updateCommitteeDelegates(
+      committee,
+      toSave,
+      this._handleSuccess,
+      this._handleError,
+    );
     event.preventDefault();
   },
 

--- a/huxley/www/js/components/ChairAttendanceView.js
+++ b/huxley/www/js/components/ChairAttendanceView.js
@@ -177,7 +177,7 @@ var ChairAttendanceView = React.createClass({
         session_one: delegate.session_one,
         session_two: delegate.session_two,
         session_three: delegate.session_three,
-        session_four: delegate.session_four
+        session_four: delegate.session_four,
       };
     }
     return attendance;
@@ -188,9 +188,9 @@ var ChairAttendanceView = React.createClass({
     var oldAttendance = attendanceMap[assignmentID];
     this.setState({
       attendance: {
-        ...attendanceMap, 
-        [assignmentID]: {...oldAttendance, [field]:!oldAttendance[field]}
-      }
+        ...attendanceMap,
+        [assignmentID]: {...oldAttendance, [field]: !oldAttendance[field]},
+      },
     });
   },
 
@@ -203,11 +203,12 @@ var ChairAttendanceView = React.createClass({
     var toSave = [];
     for (var delegate of delegates) {
       var attendance = attendanceMap[delegate.assignment];
-      var shouldSave = delegate.voting !== attendance.voting ||
-                       delegate.session_one !== attendance.session_one ||
-                       delegate.session_two !== attendance.session_two ||
-                       delegate.session_three !== attendance.session_three ||
-                       delegate.session_four !== attendance.session_four;
+      var shouldSave =
+        delegate.voting !== attendance.voting ||
+        delegate.session_one !== attendance.session_one ||
+        delegate.session_two !== attendance.session_two ||
+        delegate.session_three !== attendance.session_three ||
+        delegate.session_four !== attendance.session_four;
       if (shouldSave) {
         toSave.push({
           ...delegate,
@@ -215,7 +216,7 @@ var ChairAttendanceView = React.createClass({
           session_one: attendance.session_one,
           session_two: attendance.session_two,
           session_three: attendance.session_three,
-          session_four: attendance.session_four
+          session_four: attendance.session_four,
         });
       }
     }

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -193,9 +193,9 @@ var ChairSummaryView = React.createClass({
     var summaries = this.state.summaries;
     this.setState({
       summaries: {
-        ...summaries, 
-        [assignment.id]: event.target.value
-      }
+        ...summaries,
+        [assignment.id]: event.target.value,
+      },
     });
   },
 

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -47,7 +47,7 @@ var ChairSummaryView = React.createClass({
       loadingPublish: false,
       successPublish: false,
       delegates: delegates,
-      summaries: summaries,
+      summaries: summaries
     };
   },
 

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -33,12 +33,14 @@ var ChairSummaryView = React.createClass({
     for (var delegate of delegates) {
       summaries[delegate.assignment] = delegate.summary;
     }
+
     if (assignments.length && Object.keys(countries).length) {
       assignments.sort(
         (a1, a2) =>
           countries[a1.country].name < countries[a2.country].name ? -1 : 1,
       );
     }
+
     return {
       assignments: assignments,
       countries: countries,
@@ -47,7 +49,7 @@ var ChairSummaryView = React.createClass({
       loadingPublish: false,
       successPublish: false,
       delegates: delegates,
-      summaries: summaries
+      summaries: summaries,
     };
   },
 
@@ -108,6 +110,8 @@ var ChairSummaryView = React.createClass({
     this._countriesToken && this._countriesToken.remove();
     this._delegatesToken && this._delegatesToken.remove();
     this._assignmentsToken && this._assignmentsToken.remove();
+    this._successTimeoutSave && clearTimeout(this._successTimeoutSave);
+    this._successTimeoutPublish && clearTimeout(this._successTimeoutPublish);
   },
 
   render() {

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -28,6 +28,11 @@ var ChairSummaryView = React.createClass({
     var user = CurrentUserStore.getCurrentUser();
     var assignments = AssignmentStore.getCommitteeAssignments(user.committee);
     var countries = CountryStore.getCountries();
+    var delegates = DelegateStore.getCommitteeDelegates(user.committee);
+    var summaries = {};
+    for (var delegate of delegates) {
+      summaries[delegate.assignment] = delegate.summary;
+    }
     if (assignments.length && Object.keys(countries).length) {
       assignments.sort(
         (a1, a2) =>
@@ -37,12 +42,12 @@ var ChairSummaryView = React.createClass({
     return {
       assignments: assignments,
       countries: countries,
-      delegates: DelegateStore.getCommitteeDelegates(user.committee),
-      summaries: {},
       loadingSave: false,
       successSave: false,
       loadingPublish: false,
       successPublish: false,
+      delegates: delegates,
+      summaries: summaries,
     };
   },
 
@@ -55,20 +60,17 @@ var ChairSummaryView = React.createClass({
 
   componentDidMount() {
     var user = CurrentUserStore.getCurrentUser();
-    var delegates = this.state.delegates;
-    var summaries = this.state.summaries;
-    for (var delegate of delegates) {
-      summaries[delegate.assignment] = delegate.summary;
-    }
 
     this._delegatesToken = DelegateStore.addListener(() => {
       var delegates = DelegateStore.getCommitteeDelegates(user.committee);
+      var summaries = this.state.summaries;
+      var update = {};
       for (var delegate of delegates) {
-        summaries[delegate.assignment] = delegate.summary;
+        update[delegate.assignment] = delegate.summary;
       }
       this.setState({
         delegates: delegates,
-        summaries: summaries,
+        summaries: {...summaries, ...update},
       });
     });
 
@@ -98,8 +100,6 @@ var ChairSummaryView = React.createClass({
         countries: countries,
       });
     });
-
-    this.setState({summaries: summaries});
   },
 
   componentWillUnmount() {
@@ -188,8 +188,9 @@ var ChairSummaryView = React.createClass({
   _handleSummaryChange(assignment, event) {
     var newSummary = event.target.value;
     var summaries = this.state.summaries;
-    summaries[assignment.id] = newSummary;
-    this.setState({summaries: summaries});
+    var update = {};
+    update[assignment.id] = newSummary;
+    this.setState({summaries: {...summaries, ...update}});
   },
 
   _handleSaveSummaries(event) {

--- a/huxley/www/js/components/ChairSummaryView.js
+++ b/huxley/www/js/components/ChairSummaryView.js
@@ -190,11 +190,13 @@ var ChairSummaryView = React.createClass({
   },
 
   _handleSummaryChange(assignment, event) {
-    var newSummary = event.target.value;
     var summaries = this.state.summaries;
-    var update = {};
-    update[assignment.id] = newSummary;
-    this.setState({summaries: {...summaries, ...update}});
+    this.setState({
+      summaries: {
+        ...summaries, 
+        [assignment.id]: event.target.value
+      }
+    });
   },
 
   _handleSaveSummaries(event) {

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -12,12 +12,12 @@ var DelegationAttendanceRow = React.createClass({
     onChange: React.PropTypes.func,
     countryName: React.PropTypes.string,
     assignmentID: React.PropTypes.number,
-    attendance: React.PropTypes.object
+    attendance: React.PropTypes.object,
   },
 
   shouldComponentUpdate(nextProps, nextState) {
     for (var field in this.props.attendance) {
-      if (this.props.attendance[field] !== nextProps.attendance[field]){
+      if (this.props.attendance[field] !== nextProps.attendance[field]) {
         return true;
       }
     }
@@ -35,8 +35,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance["voting"]}
-              onChange={this._handleChange.bind(this, "voting")}
+              checked={this.props.attendance['voting']}
+              onChange={this._handleChange.bind(this, 'voting')}
             />
           </label>
         </td>
@@ -45,8 +45,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance["session_one"]}
-              onChange={this._handleChange.bind(this, "session_one")}
+              checked={this.props.attendance['session_one']}
+              onChange={this._handleChange.bind(this, 'session_one')}
             />
           </label>
         </td>
@@ -55,8 +55,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance["session_two"]}
-              onChange={this._handleChange.bind(this, "session_two")}
+              checked={this.props.attendance['session_two']}
+              onChange={this._handleChange.bind(this, 'session_two')}
             />
           </label>
         </td>
@@ -65,8 +65,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance["session_three"]}
-              onChange={this._handleChange.bind(this, "session_three")}
+              checked={this.props.attendance['session_three']}
+              onChange={this._handleChange.bind(this, 'session_three')}
             />
           </label>
         </td>
@@ -75,8 +75,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance["session_four"]}
-              onChange={this._handleChange.bind(this, "session_four")}
+              checked={this.props.attendance['session_four']}
+              onChange={this._handleChange.bind(this, 'session_four')}
             />
           </label>
         </td>
@@ -86,7 +86,7 @@ var DelegationAttendanceRow = React.createClass({
 
   _handleChange: function(field, event) {
     this.props.onChange &&
-      this.props.onChange(field, this.props.countryID, event);
+      this.props.onChange(field, this.props.assignmentID, event);
   },
 });
 

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -11,8 +11,8 @@ var DelegationAttendanceRow = React.createClass({
   propTypes: {
     onChange: React.PropTypes.func,
     countryName: React.PropTypes.string,
-    countryID: React.PropTypes.string,
-    delegates: React.PropTypes.array,
+    assignmentID: React.PropTypes.number,
+    attendance: React.PropTypes.array
   },
 
   render() {
@@ -26,8 +26,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.delegates[0].voting}
-              onChange={this._handleChange.bind(this, 'voting')}
+              checked={this.props.attendance[0]}
+              onChange={this._handleChange.bind(this, 0)}
             />
           </label>
         </td>
@@ -36,8 +36,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.delegates[0].session_one}
-              onChange={this._handleChange.bind(this, 'session_one')}
+              checked={this.props.attendance[1]}
+              onChange={this._handleChange.bind(this, 1)}
             />
           </label>
         </td>
@@ -46,8 +46,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.delegates[0].session_two}
-              onChange={this._handleChange.bind(this, 'session_two')}
+              checked={this.props.attendance[2]}
+              onChange={this._handleChange.bind(this, 2)}
             />
           </label>
         </td>
@@ -56,8 +56,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.delegates[0].session_three}
-              onChange={this._handleChange.bind(this, 'session_three')}
+              checked={this.props.attendance[3]}
+              onChange={this._handleChange.bind(this, 3)}
             />
           </label>
         </td>
@@ -66,8 +66,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.delegates[0].session_four}
-              onChange={this._handleChange.bind(this, 'session_four')}
+              checked={this.props.attendance[4]}
+              onChange={this._handleChange.bind(this, 4)}
             />
           </label>
         </td>

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -12,10 +12,20 @@ var DelegationAttendanceRow = React.createClass({
     onChange: React.PropTypes.func,
     countryName: React.PropTypes.string,
     assignmentID: React.PropTypes.number,
-    attendance: React.PropTypes.array
+    attendance: React.PropTypes.object
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    for (var field in this.props.attendance) {
+      if (this.props.attendance[field] !== nextProps.attendance[field]){
+        return true;
+      }
+    }
+    return this.props.countryName !== nextProps.countryName;
   },
 
   render() {
+    console.log(this.props.assignmentID);
     return (
       <tr>
         <td>
@@ -26,8 +36,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance[0]}
-              onChange={this._handleChange.bind(this, 0)}
+              checked={this.props.attendance["voting"]}
+              onChange={this._handleChange.bind(this, "voting")}
             />
           </label>
         </td>
@@ -36,8 +46,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance[1]}
-              onChange={this._handleChange.bind(this, 1)}
+              checked={this.props.attendance["session_one"]}
+              onChange={this._handleChange.bind(this, "session_one")}
             />
           </label>
         </td>
@@ -46,8 +56,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance[2]}
-              onChange={this._handleChange.bind(this, 2)}
+              checked={this.props.attendance["session_two"]}
+              onChange={this._handleChange.bind(this, "session_two")}
             />
           </label>
         </td>
@@ -56,8 +66,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance[3]}
-              onChange={this._handleChange.bind(this, 3)}
+              checked={this.props.attendance["session_three"]}
+              onChange={this._handleChange.bind(this, "session_three")}
             />
           </label>
         </td>
@@ -66,8 +76,8 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance[4]}
-              onChange={this._handleChange.bind(this, 4)}
+              checked={this.props.attendance["session_four"]}
+              onChange={this._handleChange.bind(this, "session_four")}
             />
           </label>
         </td>

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -25,7 +25,6 @@ var DelegationAttendanceRow = React.createClass({
   },
 
   render() {
-    console.log(this.props.assignmentID);
     return (
       <tr>
         <td>

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -21,8 +21,10 @@ var DelegationAttendanceRow = React.createClass({
         return true;
       }
     }
-    return this.props.countryName !== nextProps.countryName ||
-           this.props.assignmentID !== nextProps.assignmentID;
+    return (
+      this.props.countryName !== nextProps.countryName ||
+      this.props.assignmentID !== nextProps.assignmentID
+    );
   },
 
   render() {

--- a/huxley/www/js/components/DelegationAttendanceRow.js
+++ b/huxley/www/js/components/DelegationAttendanceRow.js
@@ -21,7 +21,8 @@ var DelegationAttendanceRow = React.createClass({
         return true;
       }
     }
-    return this.props.countryName !== nextProps.countryName;
+    return this.props.countryName !== nextProps.countryName ||
+           this.props.assignmentID !== nextProps.assignmentID;
   },
 
   render() {
@@ -35,7 +36,7 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance['voting']}
+              checked={this.props.attendance.voting}
               onChange={this._handleChange.bind(this, 'voting')}
             />
           </label>
@@ -45,7 +46,7 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance['session_one']}
+              checked={this.props.attendance.session_one}
               onChange={this._handleChange.bind(this, 'session_one')}
             />
           </label>
@@ -55,7 +56,7 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance['session_two']}
+              checked={this.props.attendance.session_two}
               onChange={this._handleChange.bind(this, 'session_two')}
             />
           </label>
@@ -65,7 +66,7 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance['session_three']}
+              checked={this.props.attendance.session_three}
               onChange={this._handleChange.bind(this, 'session_three')}
             />
           </label>
@@ -75,7 +76,7 @@ var DelegationAttendanceRow = React.createClass({
             <input
               className="choice"
               type="checkbox"
-              checked={this.props.attendance['session_four']}
+              checked={this.props.attendance.session_four}
               onChange={this._handleChange.bind(this, 'session_four')}
             />
           </label>


### PR DESCRIPTION
This makes a series of general improvements to the chair app code, partly in anticipation of #580.

Some things changed include:
- Map the relevant fields by assignment, making them independent of the delegate models
- Create new objects at state updates instead of abusing the state
- Clear the timeouts on the animations to avoid setting the state after unmount

I do think the sort calls are less elegant here but I felt it was better to place them where they would be called once instead of at every render.