### PR TITLE
Fixes registration validation bug

### DIFF
--- a/huxley/api/serializers/registration.py
+++ b/huxley/api/serializers/registration.py
@@ -50,30 +50,36 @@ class RegistrationSerializer(serializers.ModelSerializer):
             'registration_comments': {'required': False}
         }
 
-    ## This causes an issue during registration; see issue #622
-    # def validate(self, data):
-    #     invalid_fields = {}
 
-    #     num_beginner_delegates = data.get('num_beginner_delegates')
-    #     num_intermediate_delegates = data.get('num_intermediate_delegates')
-    #     num_advanced_delegates = data.get('num_advanced_delegates')
-    #     num_spanish_speaking_delegates = data.get(
-    #         'num_spanish_speaking_delegates')
-    #     num_chinese_speaking_delegates = data.get(
-    #         'num_chinese_speaking_delegates')
+    def is_registration_valid(self, raise_exception=False):
+        setattr(self.fields['school'], 'read_only', True)
+        is_valid = super(RegistrationSerializer, self).is_valid()
+        setattr(self.fields['school'], 'read_only', False)
+        return is_valid
 
-    #     total_delegates = sum(
-    #         (num_beginner_delegates or 0, num_intermediate_delegates or 0,
-    #          num_advanced_delegates or 0))
+    def validate(self, data):
+        invalid_fields = {}
 
-    #     if num_spanish_speaking_delegates > total_delegates:
-    #         invalid_fields[
-    #             'num_spanish_speaking_delegates'] = 'Cannot exceed total number of delegates.'
-    #     if num_chinese_speaking_delegates > total_delegates:
-    #         invalid_fields[
-    #             'num_chinese_speaking_delegates'] = 'Cannot exceed total number of delegates.'
+        num_beginner_delegates = data.get('num_beginner_delegates')
+        num_intermediate_delegates = data.get('num_intermediate_delegates')
+        num_advanced_delegates = data.get('num_advanced_delegates')
+        num_spanish_speaking_delegates = data.get(
+            'num_spanish_speaking_delegates')
+        num_chinese_speaking_delegates = data.get(
+            'num_chinese_speaking_delegates')
 
-    #     if invalid_fields:
-    #         raise serializers.ValidationError(invalid_fields)
+        total_delegates = sum(
+            (num_beginner_delegates or 0, num_intermediate_delegates or 0,
+             num_advanced_delegates or 0))
 
-    #     return data
+        if num_spanish_speaking_delegates > total_delegates:
+            invalid_fields[
+                'num_spanish_speaking_delegates'] = 'Cannot exceed total number of delegates.'
+        if num_chinese_speaking_delegates > total_delegates:
+            invalid_fields[
+                'num_chinese_speaking_delegates'] = 'Cannot exceed total number of delegates.'
+
+        if invalid_fields:
+            raise serializers.ValidationError(invalid_fields)
+
+        return data

--- a/huxley/api/serializers/registration.py
+++ b/huxley/api/serializers/registration.py
@@ -50,7 +50,6 @@ class RegistrationSerializer(serializers.ModelSerializer):
             'registration_comments': {'required': False}
         }
 
-
     def is_registration_valid(self, raise_exception=False):
         setattr(self.fields['school'], 'read_only', True)
         is_valid = super(RegistrationSerializer, self).is_valid()

--- a/huxley/api/serializers/registration.py
+++ b/huxley/api/serializers/registration.py
@@ -50,12 +50,6 @@ class RegistrationSerializer(serializers.ModelSerializer):
             'registration_comments': {'required': False}
         }
 
-    def is_registration_valid(self, raise_exception=False):
-        setattr(self.fields['school'], 'read_only', True)
-        is_valid = super(RegistrationSerializer, self).is_valid()
-        setattr(self.fields['school'], 'read_only', False)
-        return is_valid
-
     def validate(self, data):
         invalid_fields = {}
 

--- a/huxley/api/tests/test_register.py
+++ b/huxley/api/tests/test_register.py
@@ -125,16 +125,16 @@ class RegisterTestCase(tests.CreateAPITestCase):
 
     def test_invalid(self):
         '''It does not create a model instance on an invalid input.'''
-        params = self.get_params()
-        params['registration'] = {
+        params = self.get_params(registration={
             'conference': '65',
             'num_beginner_delegates': 1,
             'num_intermediate_delegates': 0,
             'num_advanced_delegates': 0,
             'num_spanish_speaking_delegates': 2,
             'num_chinese_speaking_delegates': 2,
-        }
+        })
 
+        response = self.get_response(params=params)
         self.assertFalse(User.objects.all().exists())
         self.assertFalse(School.objects.all().exists())
         self.assertFalse(Registration.objects.all().exists())

--- a/huxley/api/tests/test_register.py
+++ b/huxley/api/tests/test_register.py
@@ -163,8 +163,7 @@ class RegisterTestCase(tests.CreateAPITestCase):
                 'num_advanced_delegates': '',
                 'num_spanish_speaking_delegates': '',
                 'num_chinese_speaking_delegates': '',
-            }
-        )
+            })
 
         response = self.get_response(params=params)
         self.assertEqual(response.data, {
@@ -196,7 +195,6 @@ class RegisterTestCase(tests.CreateAPITestCase):
         self.assertFalse(School.objects.all().exists())
         self.assertFalse(Registration.objects.all().exists())
 
-
     def test_reg_invalid(self):
         '''It does not create User and School model instances on an invalid
            input for Registration and valid inputs for User and School.'''
@@ -211,8 +209,10 @@ class RegisterTestCase(tests.CreateAPITestCase):
 
         response = self.get_response(params=params)
         self.assertEqual(response.data, {
-            'num_spanish_speaking_delegates': ['Cannot exceed total number of delegates.'],
-            'num_chinese_speaking_delegates': ['Cannot exceed total number of delegates.']
+            'num_spanish_speaking_delegates':
+            ['Cannot exceed total number of delegates.'],
+            'num_chinese_speaking_delegates':
+            ['Cannot exceed total number of delegates.']
         })
         self.assertFalse(User.objects.all().exists())
         self.assertFalse(School.objects.all().exists())

--- a/huxley/api/tests/test_register.py
+++ b/huxley/api/tests/test_register.py
@@ -11,48 +11,47 @@ from huxley.core.models import Registration, School
 
 class RegisterTestCase(tests.CreateAPITestCase):
     url_name = 'api:register'
+    params = {
+        'user': {
+            'first_name': 'Trevor',
+            'last_name': 'Dowds',
+            'username': 'tdowds',
+            'email': 'tdowds@huxley.org',
+            'password': 'password',
+            'school': {
+                'name': 'The Trevor School',
+                'address': '123 School Way',
+                'city': 'School City',
+                'state': 'CA',
+                'zip_code': '12345',
+                'country': 'USA',
+                'international': False,
+                'program_type': ProgramTypes.CLUB,
+                'times_attended': 0,
+                'primary_name': 'Trevor Dowds',
+                'primary_gender': ContactGender.MALE,
+                'primary_email': 'tdowds@huxley.org',
+                'primary_phone': '(999) 999-9999',
+                'primary_type': ContactType.FACULTY,
+                'secondary_name': '',
+                'secondary_gender': ContactGender.MALE,
+                'secondary_email': '',
+                'secondary_phone': '',
+                'secondary_type': ContactType.FACULTY,
+            },
+        },
+        'registration': {
+            'conference': 65,
+            'num_beginner_delegates': 1,
+            'num_intermediate_delegates': 0,
+            'num_advanced_delegates': 0,
+            'num_spanish_speaking_delegates': 0,
+            'num_chinese_speaking_delegates': 0,
+        }
+    }
 
     def test_valid(self):
-        params = {
-            'user': {
-                'first_name': 'Trevor',
-                'last_name': 'Dowds',
-                'username': 'tdowds',
-                'email': 'tdowds@huxley.org',
-                'password': 'password',
-                'school': {
-                    'name': 'The Trevor School',
-                    'address': '123 School Way',
-                    'city': 'School City',
-                    'state': 'CA',
-                    'zip_code': '12345',
-                    'country': 'USA',
-                    'international': False,
-                    'program_type': ProgramTypes.CLUB,
-                    'times_attended': 0,
-                    'primary_name': 'Trevor Dowds',
-                    'primary_gender': ContactGender.MALE,
-                    'primary_email': 'tdowds@huxley.org',
-                    'primary_phone': '(999) 999-9999',
-                    'primary_type': ContactType.FACULTY,
-                    'secondary_name': '',
-                    'secondary_gender': ContactGender.MALE,
-                    'secondary_email': '',
-                    'secondary_phone': '',
-                    'secondary_type': ContactType.FACULTY,
-                },
-            },
-            'registration': {
-                'conference': 65,
-                'num_beginner_delegates': 1,
-                'num_intermediate_delegates': 0,
-                'num_advanced_delegates': 0,
-                'num_spanish_speaking_delegates': 0,
-                'num_chinese_speaking_delegates': 0,
-            }
-        }
-
-        response = self.get_response(params=params)
+        response = self.get_response(params=self.params)
         user_query = User.objects.filter(id=response.data['user']['id'])
         self.assertTrue(user_query.exists())
         school_query = School.objects.filter(
@@ -125,68 +124,17 @@ class RegisterTestCase(tests.CreateAPITestCase):
         })
 
     def test_invalid(self):
-        params = {
-            'user': {
-                'first_name': '',
-                'last_name': '',
-                'username': '',
-                'email': '',
-                'password': '',
-                'school': {
-                    'name': '',
-                    'address': '',
-                    'city': '',
-                    'state': '',
-                    'zip_code': '',
-                    'country': '',
-                    'international': False,
-                    'program_type': ProgramTypes.CLUB,
-                    'times_attended': '',
-                    'primary_name': '',
-                    'primary_gender': ContactGender.UNSPECIFIED,
-                    'primary_email': '',
-                    'primary_phone': '',
-                    'primary_type': ContactType.FACULTY,
-                    'secondary_name': '',
-                    'secondary_gender': ContactGender.UNSPECIFIED,
-                    'secondary_email': 'badformat',
-                    'secondary_phone': '',
-                    'secondary_type': ContactType.FACULTY,
-                },
-            },
-            'registration': {
-                'conference': '',
-                'num_beginner_delegates': '',
-                'num_intermediate_delegates': '',
-                'num_advanced_delegates': '',
-                'num_spanish_speaking_delegates': '',
-                'num_chinese_speaking_delegates': '',
-            }
+        '''It does not create a model instance on an invalid input.'''
+        params = self.get_params()
+        params['registration'] = {
+            'conference': '65',
+            'num_beginner_delegates': 1,
+            'num_intermediate_delegates': 0,
+            'num_advanced_delegates': 0,
+            'num_spanish_speaking_delegates': 2,
+            'num_chinese_speaking_delegates': 2,
         }
 
-        response = self.get_response(params=params)
-        self.assertEqual(response.data, {
-            'first_name': ['This field is required.'],
-            'last_name': ['This field is required.'],
-            'username': ['This field may not be blank.'],
-            'password': ['This field may not be blank.'],
-            'conference': ['This field may not be null.'],
-            'school': {
-                'city': ['This field may not be blank.'],
-                'name': ['This field may not be blank.'],
-                'primary_phone': ['This field may not be blank.'],
-                'secondary_email': ['Enter a valid email address.'],
-                'country': ['This field may not be blank.'],
-                'times_attended': ['A valid integer is required.'],
-                'state': ['This field may not be blank.'],
-                'primary_name': ['This field may not be blank.'],
-                'primary_email': ['This field may not be blank.'],
-                'address': ['This field may not be blank.'],
-                'zip_code': ['This field may not be blank.']
-            },
-            'num_advanced_delegates': ['A valid integer is required.'],
-            'num_spanish_speaking_delegates': ['A valid integer is required.'],
-            'num_chinese_speaking_delegates': ['A valid integer is required.'],
-            'num_intermediate_delegates': ['A valid integer is required.'],
-            'num_beginner_delegates': ['A valid integer is required.'],
-        })
+        self.assertFalse(User.objects.all().exists())
+        self.assertFalse(School.objects.all().exists())
+        self.assertFalse(Registration.objects.all().exists())

--- a/huxley/api/views/register.py
+++ b/huxley/api/views/register.py
@@ -34,11 +34,13 @@ class Register(generics.GenericAPIView):
             user_serializer = self.serializer_classes['user'](data=user_data)
             user_is_valid = user_serializer.is_valid()
             if not user_is_valid:
-                registration_serializer = self.serializer_classes['registration'](data=registration_data)
+                registration_serializer = self.serializer_classes[
+                    'registration'](data=registration_data)
                 registration_serializer.is_valid()
                 errors = registration_serializer.errors
                 errors.update(user_serializer.errors)
-                return response.Response(errors, status=status.HTTP_400_BAD_REQUEST)
+                return response.Response(
+                    errors, status=status.HTTP_400_BAD_REQUEST)
 
             user_serializer.save()
             school_id = user_serializer.data['school']['id']

--- a/huxley/api/views/register.py
+++ b/huxley/api/views/register.py
@@ -26,13 +26,13 @@ class Register(generics.GenericAPIView):
 
     def register(self, request, *args, **kwargs):
         user_data = request.data['user']
-        registration_data = request.data['registration']
         user_serializer = self.serializer_classes['user'](data=user_data)
+        is_user_valid = user_serializer.is_valid()
+
+        registration_data = request.data['registration']
         registration_serializer = self.serializer_classes['registration'](
             data=registration_data)
-        is_user_valid = user_serializer.is_valid()
-        is_registration_valid = self.is_registration_valid(
-            registration_serializer)
+        is_registration_valid = registration_serializer.is_registration_valid()
 
         if is_user_valid and is_registration_valid:
             user_serializer.save()
@@ -51,8 +51,3 @@ class Register(generics.GenericAPIView):
             response_status = status.HTTP_400_BAD_REQUEST
 
         return response.Response(data, status=response_status)
-
-    def is_registration_valid(self, registration_serializer):
-        registration_serializer.is_valid()
-        errors = registration_serializer.errors
-        return len(errors) == 1 and 'school' in errors

--- a/huxley/api/views/register.py
+++ b/huxley/api/views/register.py
@@ -37,10 +37,11 @@ class Register(generics.GenericAPIView):
 
             school_id = user_serializer.data['school']['id']
             registration_data['school'] = school_id
-            registration_serializer = self.serializer_classes['registration'](data=registration_data)
+            registration_serializer = self.serializer_classes['registration'](
+                data=registration_data)
             registration_serializer.is_valid(raise_exception=True)
             registration_serializer.save()
 
         data = {'user': user_serializer.data,
-                    'registration': registration_serializer.data}
+                'registration': registration_serializer.data}
         return response.Response(data, status=status.HTTP_200_OK)

--- a/huxley/api/views/register.py
+++ b/huxley/api/views/register.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2011-2017 Berkeley Model United Nations. All rights reserved.
 # Use of this source code is governed by a BSD License (see LICENSE).
 
+from django.db import transaction
+
 from rest_framework import generics, response, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import PermissionDenied
@@ -26,28 +28,19 @@ class Register(generics.GenericAPIView):
 
     def register(self, request, *args, **kwargs):
         user_data = request.data['user']
-        user_serializer = self.serializer_classes['user'](data=user_data)
-        is_user_valid = user_serializer.is_valid()
-
         registration_data = request.data['registration']
-        registration_serializer = self.serializer_classes['registration'](
-            data=registration_data)
-        is_registration_valid = registration_serializer.is_registration_valid()
 
-        if is_user_valid and is_registration_valid:
+        with transaction.atomic():
+            user_serializer = self.serializer_classes['user'](data=user_data)
+            user_serializer.is_valid(raise_exception=True)
             user_serializer.save()
-            school_id = School.objects.get(name=user_data['school']['name']).id
-            registration_data['school'] = school_id
-            registration_serializer = self.serializer_classes['registration'](
-                data=registration_data)
-            registration_serializer.is_valid()
-            registration_serializer.save()
-            data = {'user': user_serializer.data,
-                    'registration': registration_serializer.data}
-            response_status = status.HTTP_200_OK
-        else:
-            data = registration_serializer.errors.copy()
-            data.update(user_serializer.errors)
-            response_status = status.HTTP_400_BAD_REQUEST
 
-        return response.Response(data, status=response_status)
+            school_id = user_serializer.data['school']['id']
+            registration_data['school'] = school_id
+            registration_serializer = self.serializer_classes['registration'](data=registration_data)
+            registration_serializer.is_valid(raise_exception=True)
+            registration_serializer.save()
+
+        data = {'user': user_serializer.data,
+                    'registration': registration_serializer.data}
+        return response.Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Fix for #622 

The issue appears to be that the validation method of a DRF serializer doesn't get called when a required field is empty. With the way `RegisterView` works, it assumes that the school field of the registration data of the request will be empty until the school is created on the User. Unfortunately, this means that the validation method of `RegistrationSerializer` will never be called because the school field will always be empty based off our assumption. The fix for this proposed here is to temporarily set the school field to read only, so that way it doesn't do any validation on the school field of the Registration object. 

Here are some relevant links from DRF's source code for reference:
[is_valid](https://github.com/encode/django-rest-framework/blob/master/rest_framework/serializers.py#L222)
[run_validation](https://github.com/encode/django-rest-framework/blob/master/rest_framework/serializers.py#L422)
[to_internal_value](https://github.com/encode/django-rest-framework/blob/master/rest_framework/serializers.py#L442)