### PR TITLE
Fixes Assignment Upload

### DIFF
--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -335,7 +335,8 @@ class Assignment(models.Model):
                 is_invalid = True
             else:
                 try:
-                    registration = Registration.objects.get(school_id=school.id)
+                    registration = Registration.objects.get(
+                        school_id=school.id)
                 except Registration.DoesNotExist:
                     is_invalid = True
 

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -103,12 +103,20 @@ class AssignmentTest(TestCase):
             (cm2, ct3, s2, False),  # ADDED
         ]
 
+        all_assignments = [
+            (cm1.id, ct1.id, r1.id, False),
+            (cm1.id, ct2.id, r1.id, False),
+            (cm1.id, ct3.id, r1.id, False),
+            (cm2.id, ct2.id, r2.id, False),
+            (cm2.id, ct3.id, r2.id, False),
+            (cm2.id, ct1.id, r1.id, False),
+        ]
+
         Assignment.update_assignments(updates)
-        new_assignments = [a[1:]
-                           for a in Assignment.objects.all().values_list()]
+        assignments = [a[1:] for a in Assignment.objects.all().values_list()]
         delegates = Delegate.objects.all()
         updates = [(cm.id, ct.id, s.id, rej) for cm, ct, s, rej in updates]
-        self.assertEquals(set(updates), set(new_assignments))
+        self.assertEquals(set(all_assignments), set(assignments))
         self.assertEquals(len(delegates), 2)
 
     def test_update_assignment(self):

--- a/huxley/core/tests/models/test_models.py
+++ b/huxley/core/tests/models/test_models.py
@@ -115,7 +115,6 @@ class AssignmentTest(TestCase):
         Assignment.update_assignments(updates)
         assignments = [a[1:] for a in Assignment.objects.all().values_list()]
         delegates = Delegate.objects.all()
-        updates = [(cm.id, ct.id, s.id, rej) for cm, ct, s, rej in updates]
         self.assertEquals(set(all_assignments), set(assignments))
         self.assertEquals(len(delegates), 2)
 


### PR DESCRIPTION
This fixes #627 by modifying the assignment update function to account for the registration model, as well as fixing some other bugs I noticed:
1. We pass strings as a signal that a model does not exist, but we were checking model ids before checking that the objects were not strings
2. I can't think of any good reason to remove the remainder of assignment_dict unless we explicitly want to remove all old assignments, something External very emphatically does not want to happen. By taking that out now the uploaded csv just updates the set of assignments without replacing them.