### PR TITLE
Delete Delegate Accounts

### DIFF
--- a/huxley/accounts/models.py
+++ b/huxley/accounts/models.py
@@ -29,8 +29,11 @@ class User(AbstractUser):
         Committee, related_name='chair', null=True, blank=True)  # Chairs only
 
     delegate = models.OneToOneField(
-        Delegate, related_name='delegate', null=True,
-        blank=True, on_delete=models.CASCADE)  # Delegate only
+        Delegate,
+        related_name='delegate',
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE)  # Delegate only
 
     def is_advisor(self):
         return self.user_type == self.TYPE_ADVISOR

--- a/huxley/accounts/models.py
+++ b/huxley/accounts/models.py
@@ -30,7 +30,7 @@ class User(AbstractUser):
 
     delegate = models.OneToOneField(
         Delegate, related_name='delegate', null=True,
-        blank=True)  # Delegate only
+        blank=True, on_delete=models.CASCADE)  # Delegate only
 
     def is_advisor(self):
         return self.user_type == self.TYPE_ADVISOR


### PR DESCRIPTION
This is to ensure accounts get deleted with their delegates (the last part of #614)