### PR TITLE
Committee Preference Modifications

### DIFF
--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -129,7 +129,7 @@ class Registration(models.Model):
     country_preferences = models.ManyToManyField(
         Country, through='CountryPreference')
     committee_preferences = models.ManyToManyField(
-        Committee, limit_choices_to={'special': True})
+        Committee, blank=True, null=True)
 
     registration_comments = models.TextField(default='', blank=True)
 


### PR DESCRIPTION
This is from External's request; it allows the committee preferences to be empty and for someone in the backend to select a non-specialized committee (this doesn't not change the frontend; during registration advisors can still only select specialized committees)