### PR TITLE
Fixed special characters in delegate emails.

### DIFF
--- a/huxley/api/serializers/delegate.py
+++ b/huxley/api/serializers/delegate.py
@@ -51,7 +51,7 @@ class DelegateSerializer(serializers.ModelSerializer):
                 email=instance.email,
                 last_login=datetime.now())
 
-            send_mail('A new account has been created for {0}!\n'.format(instance.name.encode('utf8')),
+            send_mail('A new account has been created for {0}!'.format(instance.name.encode('utf8')),
                       'Username: {0}\n'.format(username.encode('utf8')) \
 
                       + 'Password: {0}\n'.format(password) \

--- a/huxley/api/serializers/delegate.py
+++ b/huxley/api/serializers/delegate.py
@@ -36,7 +36,6 @@ class DelegateSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         if ('assignment' in validated_data and
                 validated_data['assignment'] != None and
-                not instance.assignment and
                 not User.objects.filter(delegate__id=instance.id).exists()):
 
             names = instance.name.split(' ')
@@ -52,11 +51,12 @@ class DelegateSerializer(serializers.ModelSerializer):
                 email=instance.email,
                 last_login=datetime.now())
 
-            send_mail('An account has been created for {0}.'.format(instance.name),
-                      'Username: {0}\n'.format(username) \
+            send_mail('A new account has been created for {0}!\n'.format(instance.name.encode('utf8')),
+                      'Username: {0}\n'.format(username.encode('utf8')) \
+
                       + 'Password: {0}\n'.format(password) \
-                      + 'Please save this information! You will need it for '
-                      + 'important information and actions. You can access '
+                      + 'Please save this information! You will need it for ' \
+                      + 'important information and actions. You can access ' \
                       + 'this account at huxley.bmun.org.',
                       'no-reply@bmun.org',
                       [instance.email], fail_silently=False)


### PR DESCRIPTION
Made a few changes to explicitly encode strings with unicode in order to avoid this error.