### PR TITLE
Fix for failed assignment uploads

### DIFF
--- a/huxley/core/models.py
+++ b/huxley/core/models.py
@@ -565,6 +565,11 @@ class Assignment(models.Model):
                 Assignment.objects.filter(id__in=deletions).delete()
                 Assignment.objects.bulk_create(additions)
 
+        else:
+            #If the update failed in some way we would like to delete the position paper
+            # objects that were created in the process.
+            PositionPaper.objects.filter(assignment=None).delete()
+
         return failed_assignments
 
     @classmethod


### PR DESCRIPTION
Now when assignment upload fails, all position paper objects that were created in the process are deleted.