### PR TITLE
Password reset

### DIFF
--- a/huxley/accounts/models.py
+++ b/huxley/accounts/models.py
@@ -80,11 +80,12 @@ class User(AbstractUser):
         new_password = cls.objects.make_random_password(length=10)
         user.set_password(new_password)
         user.save()
-
+        
         user.email_user(
-            'Huxley Password Reset',
-            'The password for user %s '
-            'has been reset to %s.\n'
+            'Berkeley Model UN Huxley Password Reset',
+            'Your password has been successfully reset!\n'
+            'Username: %s\n'
+            'Password: %s\n'
             'Thank you for using Huxley!' % (user.username, new_password),
             from_email='no-reply@bmun.org')
 

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -259,10 +259,7 @@ class AdvisorRosterView extends React.Component {
                   size="small"
                   onClick={e => 
                     window.confirm(`Are you sure you wish to reset the password for ${delegate.name}? The delegate will no longer be able to log in with the old password. Please ensure that the delegate's email is entered correctly: ${delegate.email}`) 
-                    && this._handleDelegatePasswordChange.bind(
-                      this,
-                      delegate
-                  )()}
+                    && this._handleDelegatePasswordChange(delegate)}
                 >
                   Reset Password
                 </Button>

--- a/huxley/www/js/components/AdvisorRosterView.js
+++ b/huxley/www/js/components/AdvisorRosterView.js
@@ -257,10 +257,12 @@ class AdvisorRosterView extends React.Component {
                 <Button
                   color="yellow"
                   size="small"
-                  onClick={this._handleDelegatePasswordChange.bind(
-                    this,
-                    delegate
-                  )}
+                  onClick={e => 
+                    window.confirm(`Are you sure you wish to reset the password for ${delegate.name}? The delegate will no longer be able to log in with the old password. Please ensure that the delegate's email is entered correctly: ${delegate.email}`) 
+                    && this._handleDelegatePasswordChange.bind(
+                      this,
+                      delegate
+                  )()}
                 >
                   Reset Password
                 </Button>
@@ -329,7 +331,7 @@ class AdvisorRosterView extends React.Component {
 
   _handleDelegatePasswordChange = (delegate) => {
     ServerAPI.resetDelegatePassword(delegate.id).then(
-      this._handlePasswordChangeSuccess,
+      ()=>this._handlePasswordChangeSuccess(delegate.email),
       this._handlePasswordChangeError
     );
   };
@@ -342,12 +344,12 @@ class AdvisorRosterView extends React.Component {
     });
   };
 
-  _handlePasswordChangeSuccess = () => {
+  _handlePasswordChangeSuccess = (email) => {
     this.setState({
       loading: false,
       modal_open: false,
     });
-    window.alert(`Password successfully reset.`);
+    window.alert(`Password successfully reset. An email containing the password has been sent to ${email}.`);
   };
 
   _handlePasswordChangeError = () => {


### PR DESCRIPTION
Resolves #758 

Email content changed but Untested.

Advisor confirmation is as follows:
Confirmation Screen
<img width="799" alt="Screen Shot 2022-01-16 at 5 02 16 PM" src="https://user-images.githubusercontent.com/15204179/149685856-4653a9b6-7fad-4f93-b6ef-a59ed5c7ae79.png">
followed by an alert if the password was successfully changed.
<img width="791" alt="Screen Shot 2022-01-16 at 4 59 42 PM" src="https://user-images.githubusercontent.com/15204179/149685868-a4a136bb-de65-412b-b7e7-28229ee90cea.png">

