### PR TITLE
fixing waiver text and hiding committee zoom links

### DIFF
--- a/huxley/www/js/components/DelegateProfileView.js
+++ b/huxley/www/js/components/DelegateProfileView.js
@@ -124,35 +124,35 @@ class DelegateProfileView extends React.Component {
       </table>
     );
 
-    if (committee) { 
-      if (delegate && delegate.waiver_submitted) {
-        zoomLinkText = (
-                  <div>
-                    <th>Committee Zoom Link</th>
-                    <br />
-                    <Button
-                      color="blue"
-                      size="small"
-                      onClick={() => window.open(committee.zoom_link, "_blank")}
-                    >
-                      Click here to join committee!
-                    </Button>
-                  </div>
-                  );
-      } else {
-        zoomLinkText = (
-                  <div>
-                    <th>Committee Zoom Link</th>
-                    <b />
-                    <TextTemplate
-                      opiLink = {global.conference.opi_link}
-                    >
-                      {DelegateProfileNoZoomViewText}
-                    </TextTemplate>
-                  </div>
-                  );
-      }    
-    }
+    // if (committee) { 
+    //   if (delegate && delegate.waiver_submitted) {
+    //     zoomLinkText = (
+    //               <div>
+    //                 <th>Committee Zoom Link</th>
+    //                 <br />
+    //                 <Button
+    //                   color="blue"
+    //                   size="small"
+    //                   onClick={() => window.open(committee.zoom_link, "_blank")}
+    //                 >
+    //                   Click here to join committee!
+    //                 </Button>
+    //               </div>
+    //               );
+    //   } else {
+    //     zoomLinkText = (
+    //               <div>
+    //                 <th>Committee Zoom Link</th>
+    //                 <b />
+    //                 <TextTemplate
+    //                   opiLink = {global.conference.opi_link}
+    //                 >
+    //                   {DelegateProfileNoZoomViewText}
+    //                 </TextTemplate>
+    //               </div>
+    //               );
+    //   }    
+    // }
 
     if (delegate.published_summary) {
       summary = (

--- a/huxley/www/js/text/checklists/DelegateChecklistWaiverText.md
+++ b/huxley/www/js/text/checklists/DelegateChecklistWaiverText.md
@@ -1,3 +1,5 @@
 All delegates are required to turn in a medical and media release waiver prior to attending conference.  Waiver completion is due on **{{ waiverDeadline }}**. The waiver will become available on **{{ waiverAvail }}**. <a href="{{ waiverLink }}" target="_blank"> The link to the waiver will be here </a>
 
+IMPORTANT: Any waiver submissions prior to **{{ waiverAvail }}** will be considered invalid, and you will need to submit another waiver on or after **{{ waiverAvail }}**.
+
 This checklist item is updated manually by BMUN's Under-Secretary-General of External Relations, {{ conferenceExternal }}, every non-holiday Wednesday and Sunday night on a rolling basis. If you have submitted a waiver electronically and this item has not been checked, please contact info@bmun.org.


### PR DESCRIPTION
* Waiver text should also note that waivers submitted too early are not accepted
* Temporary fix: committee zoom links should be hidden for an in-person conference
* NOTE: should add to conference model to hide committee zoom links for a more adaptive solution in the future