### PR TITLE
Hotfixes

### DIFF
--- a/huxley/www/js/components/AdvisorProfileView.js
+++ b/huxley/www/js/components/AdvisorProfileView.js
@@ -152,8 +152,9 @@ class AdvisorProfileView extends React.Component {
       for (var i = 0; i < assignments.length; i++) {
         if (
           assignments[i] == null ||
-          assignments[i].paper == null ||
-          assignments[i].paper.file == null
+          (assignments[i].rejected == false &&
+          (assignments[i].paper == null ||
+          assignments[i].paper.file == null))
         ) {
           positionPapersTurnedIn = "\u2610";
           break;

--- a/huxley/www/js/components/PaperGradeTable.js
+++ b/huxley/www/js/components/PaperGradeTable.js
@@ -38,7 +38,9 @@ class PaperGradeTable extends React.Component {
           : null;
       var fileNames = paper.file.split("/");
       var fileName = fileNames[fileNames.length - 1];
-      var gradedName = gradedHrefData ? "graded_" + fileName : null;
+      var gradedFileNames = paper.graded_file.split("/");
+      var gradedFileName = gradedFileNames[gradedFileNames.length - 1];
+      var gradedName = gradedHrefData ? "graded_" + gradedFileName : null;
       var downloadGraded = gradedHrefData ? (
         <a
           className={cx({


### PR DESCRIPTION
* Graded papers were using the uploaded paper filename and extension. This was causing problems especially if the delegate uploaded paper was a different format such as .docx than the graded paper which may have been .pdf. 

* Rejected assignments should not be factored in for the Advisor checklist when checking that all position papers are submitted