### PR TITLE
Update arabic-reshaper to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amqp==5.0.9
-arabic-reshaper==2.1.3
+arabic-reshaper==3.0.0
 asgiref==3.3.4
 billiard==3.6.4.0
 cachetools==4.2.2


### PR DESCRIPTION
When installing dependencies, we come across the following error:
`ERROR: Could not find a version that satisfies the requirement arabic-reshaper==2.1.3 (from versions: 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8, 2.0.9, 2.0.10, 2.0.11, 2.0.14, 2.0.15, 2.1.0, 2.1.1, 2.1.4, 3.0.0)`

This upgrades arabic-reshaper to the newest version (3.0.0)